### PR TITLE
Customize `max_line_length`, remove unused dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ from telegramify_markdown import customize
 customize.markdown_symbol.head_level_1 = "📌"  # If you want, Customizing the head level 1 symbol
 customize.markdown_symbol.link = "🔗"  # If you want, Customizing the link symbol
 customize.strict_markdown = True  # If you want to use __underline__ as underline, set it to False or it will be converted to bold.
+customize.max_line_length = 25 # If you want to change the max line length for links, images, and other elements, set it to the desired value.
 markdown_text = """
 '\_', '\*', '\[', '\]', '\(', '\)', '\~', '\`', '\>', '\#', '\+', '\-', '\=', '\|', '\{', '\}', '\.', '\!'
 _ , * , [ , ] , ( , ) , ~ , ` , > , # , + , - , = , | , { , } , . , !

--- a/pdm.lock
+++ b/pdm.lock
@@ -128,15 +128,6 @@ files = [
 ]
 
 [[package]]
-name = "html"
-version = "1.16"
-summary = ""
-groups = ["default"]
-files = [
-    {file = "html-1.16.tar.gz", hash = "sha256:ebc768f23b54a71350d731a75f2ef3a4a4dbdad9ae68d58b527664b66088e456"},
-]
-
-[[package]]
 name = "idna"
 version = "3.7"
 requires_python = ">=3.5"

--- a/src/telegramify_markdown/customize.py
+++ b/src/telegramify_markdown/customize.py
@@ -17,3 +17,4 @@ class Symbol(object):
 markdown_symbol = Symbol()
 strict_markdown = True
 unescape_html = False
+max_line_length = 20

--- a/src/telegramify_markdown/render.py
+++ b/src/telegramify_markdown/render.py
@@ -6,7 +6,7 @@ from mistletoe import block_token, span_token
 from mistletoe.markdown_renderer import MarkdownRenderer, LinkReferenceDefinition, Fragment
 from telebot import formatting
 
-from .customize import markdown_symbol, strict_markdown
+from .customize import markdown_symbol, strict_markdown, max_line_length
 
 
 def escape_markdown(content: str, unescape_html: bool = True) -> str:
@@ -140,7 +140,7 @@ class TelegramMarkdownRenderer(MarkdownRenderer):
     def render_link_or_image(
             self, token: span_token.SpanToken, target: str
     ) -> Iterable[Fragment]:
-        title = next(self.span_to_lines(token.children, max_line_length=20), "")
+        title = next(self.span_to_lines(token.children, max_line_length=max_line_length), "")
         if token.dest_type == "uri" or token.dest_type == "angle_uri":
             # "[" description "](" dest_part [" " title] ")"
             # "[" description "](" dest_part [" " title] ")"


### PR DESCRIPTION
This PR removes `html` package from the lockfile (it seems to be added on accident since it's a Python 2 package) and adds the ability to customize the length of link previews (that we previously limited to 20 chars).