### PR TITLE
chore: set version to 1.0.0rc1 for pre-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ produces `(text, entities)` tuples that can be sent directly via the Telegram Bo
 > [!NOTE]
 > v1.0.0 is a breaking change from 0.x. The output is now `(str, list[MessageEntity])` instead of a MarkdownV2 string.
 > The old `markdownify()` and `standardize()` functions have been removed.
+>
+> **Currently in release candidate.** Install with `pip install telegramify-markdown==1.0.0rc1` to try it.
+> The default `pip install telegramify-markdown` still installs the stable 0.5.x version.
 
 ## For AI Coding Assistants
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegramify-markdown"
-version = "1.0.0"
+version = "1.0.0rc1"
 description = "Convert Markdown to Telegram plain text + MessageEntity pairs"
 authors = [
     { name = "sudoskys", email = "coldlando@hotmail.com" },


### PR DESCRIPTION
## Summary

- Set version to `1.0.0rc1` so that `pip install telegramify-markdown` continues to install the stable 0.5.x
- Users opt in with `pip install telegramify-markdown==1.0.0rc1`
- Updated README with release candidate notice and install instructions

Follow-up to #95 (merged).