### PR TITLE
fix: restore proper block spacing (\n\n) between blocks

### DIFF
--- a/src/telegramify_markdown/converter.py
+++ b/src/telegramify_markdown/converter.py
@@ -131,6 +131,17 @@ class _TextBuffer:
     def py_offset(self) -> int:
         return sum(len(p) for p in self._parts)
 
+    def trailing_newline_count(self) -> int:
+        """Count trailing newline characters in the buffer."""
+        count = 0
+        for part in reversed(self._parts):
+            for ch in reversed(part):
+                if ch == "\n":
+                    count += 1
+                else:
+                    return count
+        return count
+
     def get_text(self) -> str:
         return "".join(self._parts)
 
@@ -643,9 +654,12 @@ class EventWalker:
         )
 
     def _ensure_block_spacing(self) -> None:
-        """Write a newline separator between blocks if we're not at the start."""
+        """Ensure a blank line (\\n\\n) between blocks, avoiding excess newlines."""
         if self._block_count > 0:
-            self._buf.write("\n")
+            trailing = self._buf.trailing_newline_count()
+            needed = 2 - trailing
+            if needed > 0:
+                self._buf.write("\n" * needed)
 
 
 # --- Public API ---------------------------------------------------------------

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -228,7 +228,7 @@ class RuleTest(unittest.TestCase):
 class ParagraphSpacingTest(unittest.TestCase):
     def test_paragraphs_separated(self):
         text, entities = convert("para1\n\npara2", latex_escape=False)
-        self.assertIn("para1\npara2", text)
+        self.assertIn("para1\n\npara2", text)
 
     def test_heading_then_paragraph(self):
         text, entities = convert("# Title\n\nContent", latex_escape=False)


### PR DESCRIPTION
## Problem

`_ensure_block_spacing` in the pyromark-based rewrite writes only a single `\n` between block-level elements, causing two issues:

1. Missing blank lines - paragraphs, headings, rules, and other blocks are separated by a single newline instead of a blank line, making the output look cramped
2. Extra blank lines - list => blockquote transitions produce a triple `\n\n\n` because `_on_end_item` already writes `\n`, then both `_on_start_blockquote` and the paragraph inside the blockquote each call `_ensure_block_spacing`, stacking up newlines

## Fix

Added `trailing_newline_count()` to `_TextBuffer` and made `_ensure_block_spacing` target exactly `\n\n` between blocks by writing only what's needed:

- 0 trailing newlines (after paragraph/heading text) => writes `\n\n`
- 1 trailing newline (after list item's `\n`) => writes `\n`
- 2+ trailing newlines (e.g. inside blockquote after its start spacing) => writes nothing

## Comparison

### Input

```markdown
**Bold Title**

Paragraph after bold.

---

### 1. Heading

Text after heading.

*  Item one
*  Item two
*  Item three

> A blockquote here

---

### 2. Another Heading

More text.
```

### Stable branch (`39eccad`, mistletoe)

```
*Bold Title*

Paragraph after bold\.

--------

*📚 1\. Heading*

Text after heading\.

⦁  Item one
⦁  Item two
⦁  Item three

>A blockquote here

--------

*📚 2\. Another Heading*

More text\.
```

### Current `main` (pyromark rewrite)

Everything is crammed together with single newlines, **except** after the list where there's a triple newline:

```
Bold Title
Paragraph after bold.
--------
📚 1. Heading
Text after heading.
⦁ Item one
⦁ Item two
⦁ Item three


A blockquote here
--------
📚 2. Another Heading
More text.
```

### This PR

Restores proper `\n\n` blank-line separation between all blocks, matching the stable branch behavior:

```
Bold Title

Paragraph after bold.

--------

📚 1. Heading

Text after heading.

⦁ Item one
⦁ Item two
⦁ Item three

A blockquote here

--------

📚 2. Another Heading

More text.
```
