### PR TITLE
feat: restore 0.x compat API and release 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![PyPI version](https://badge.fury.io/py/telegramify-markdown.svg)](https://badge.fury.io/py/telegramify-markdown)
 [![Downloads](https://pepy.tech/badge/telegramify-markdown)](https://pepy.tech/project/telegramify-markdown)
 
-**Effortlessly convert raw Markdown to Telegram plain text
-+ [MessageEntity](https://core.telegram.org/bots/api#messageentity) pairs.**
+**Effortlessly convert raw Markdown to Telegram plain text +
+[MessageEntity](https://core.telegram.org/bots/api#messageentity) pairs.**
 
 Say goodbye to MarkdownV2 escaping headaches! This library parses Markdown (including LLM output, GitHub READMEs, etc.)
 and produces `(text, entities)` tuples that can be sent directly via the Telegram Bot API — no `parse_mode` needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegramify-markdown"
-version = "1.0.0rc5"
+version = "1.0.0"
 description = "Convert Markdown to Telegram plain text + MessageEntity pairs"
 authors = [
     { name = "sudoskys", email = "coldlando@hotmail.com" },

--- a/src/telegramify_markdown/__init__.py
+++ b/src/telegramify_markdown/__init__.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Union
 
 from telegramify_markdown import config
 from telegramify_markdown.converter import convert as convert
 from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
-from telegramify_markdown.content import ContentType, ContentTrace, File, Photo, Text
+from telegramify_markdown.content import ContentType, ContentTypes, ContentTrace, File, Photo, Text
 from telegramify_markdown.mdv2 import entities_to_markdownv2
 
 __all__ = [
     "convert",
     "telegramify",
     "entities_to_markdownv2",
+    "markdownify",
+    "standardize",
     "config",
     "MessageEntity",
     "utf16_len",
@@ -22,27 +25,49 @@ __all__ = [
     "File",
     "Photo",
     "ContentType",
+    "ContentTypes",
     "ContentTrace",
 ]
+
+
+def markdownify(content: str, *, latex_escape: bool = True) -> str:
+    """Convert Markdown to a Telegram MarkdownV2 string.
+
+    For middleware that only supports ``parse_mode="MarkdownV2"`` without entities.
+    Equivalent to ``entities_to_markdownv2(*convert(content))``.
+    """
+    return entities_to_markdownv2(*convert(content, latex_escape=latex_escape))
+
+
+def standardize(content: str, *, latex_escape: bool = True) -> str:
+    """Alias for :func:`markdownify`, kept for 0.x compatibility."""
+    return markdownify(content, latex_escape=latex_escape)
 
 
 async def telegramify(
     content: str,
     *,
     max_message_length: int = 4096,
+    max_word_count: int | None = None,
     latex_escape: bool = True,
 ) -> list[Union[Text, File, Photo]]:
     """Convert markdown to Telegram-ready content segments.
 
-    This is the primary async API for complete markdown processing,
-    including message splitting, code block extraction, and mermaid rendering.
-    For lower-level text-only conversion, use ``convert()``.
-
     :param content: Raw markdown text.
     :param max_message_length: Maximum UTF-16 code units per text message (Telegram limit is 4096).
+    :param max_word_count: Deprecated alias for *max_message_length*. Will be removed in 2.0.
     :param latex_escape: Whether to convert LaTeX ``\\(...\\)`` and ``\\[...\\]`` to Unicode.
     :return: Ordered list of Text, File, or Photo objects ready for the Telegram Bot API.
     """
+    if max_word_count is not None:
+        warnings.warn(
+            "max_word_count is deprecated and will be removed in 2.0. "
+            "Use max_message_length instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        max_message_length = max_word_count
+
     from telegramify_markdown.pipeline import process_markdown
 
     return await process_markdown(

--- a/src/telegramify_markdown/content.py
+++ b/src/telegramify_markdown/content.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from enum import Enum
 
 from telegramify_markdown.entity import MessageEntity
@@ -12,10 +13,38 @@ class ContentType(Enum):
     PHOTO = "photo"
 
 
+# 0.x compat alias
+ContentTypes = ContentType
+
+
 @dataclasses.dataclass
 class ContentTrace:
     source_type: str
     extra: dict = dataclasses.field(default_factory=dict)
+
+
+def _deprecated_property(old: str, new: str, is_mdv2: bool = False):
+    """Create a property that emits a DeprecationWarning on access."""
+
+    def _getter(self):
+        warnings.warn(
+            f".{old} is deprecated and will be removed in 2.0. Use .{new} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if is_mdv2:
+            from telegramify_markdown.mdv2 import entities_to_markdownv2
+
+            text_attr = new  # "text" or "caption_text"
+            entities_attr = (
+                "entities" if text_attr == "text" else "caption_entities"
+            )
+            return entities_to_markdownv2(
+                getattr(self, text_attr), getattr(self, entities_attr)
+            )
+        return getattr(self, new)
+
+    return property(_getter)
 
 
 @dataclasses.dataclass
@@ -24,6 +53,9 @@ class Text:
     entities: list[MessageEntity]
     content_trace: ContentTrace
     content_type: ContentType = ContentType.TEXT
+
+    # 0.x compat: .content → MarkdownV2 string
+    content = _deprecated_property("content", "text", is_mdv2=True)
 
 
 @dataclasses.dataclass
@@ -35,6 +67,9 @@ class File:
     caption_entities: list[MessageEntity] = dataclasses.field(default_factory=list)
     content_type: ContentType = ContentType.FILE
 
+    # 0.x compat: .caption → MarkdownV2 string
+    caption = _deprecated_property("caption", "caption_text", is_mdv2=True)
+
 
 @dataclasses.dataclass
 class Photo:
@@ -44,3 +79,6 @@ class Photo:
     caption_text: str = ""
     caption_entities: list[MessageEntity] = dataclasses.field(default_factory=list)
     content_type: ContentType = ContentType.PHOTO
+
+    # 0.x compat: .caption → MarkdownV2 string
+    caption = _deprecated_property("caption", "caption_text", is_mdv2=True)

--- a/src/telegramify_markdown/type.py
+++ b/src/telegramify_markdown/type.py
@@ -1,0 +1,34 @@
+"""0.x compat module. Migrate to telegramify_markdown.content."""
+
+from __future__ import annotations
+
+import warnings as _warnings
+
+_warnings.warn(
+    "telegramify_markdown.type is deprecated and will be removed in 2.0. "
+    "Use telegramify_markdown.content instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from telegramify_markdown.content import (  # noqa: E402, F401
+    ContentTrace,
+    ContentType as ContentTypes,
+    File,
+    Photo,
+    Text,
+)
+from typing import List, Tuple, Any, Union  # noqa: E402, F401
+
+SentType = List[Union[Text, File, Photo]]
+TaskType = Tuple[str, List[Tuple[Any, Any]]]
+
+__all__ = [
+    "ContentTypes",
+    "ContentTrace",
+    "Text",
+    "File",
+    "Photo",
+    "SentType",
+    "TaskType",
+]


### PR DESCRIPTION
## Summary

- Restore `markdownify()` and `standardize()` as first-class MarkdownV2 output API for middleware that only supports `parse_mode="MarkdownV2"` without entities (#101)
- Add 0.x backward-compatible shims with `DeprecationWarning` (scheduled removal in 2.0):
  - `Text.content`, `File.caption`, `Photo.caption` properties → auto-convert to MarkdownV2
  - `telegramify_markdown.type` module re-exporting from `content`
  - `ContentTypes` alias for `ContentType`
  - `telegramify(max_word_count=...)` parameter alias for `max_message_length`
- Fix README syntax error: `+` at line start was parsed as list item
- Bump version to **1.0.0**

### 0.x → 1.0 migration

| 0.x code | 1.0 behavior | Warning? |
|----------|-------------|----------|
| `markdownify(md)` | Works as-is, first-class API | No |
| `standardize(md)` | Works as-is, alias for markdownify | No |
| `telegramify(md, max_word_count=N)` | Works, forwards to max_message_length | DeprecationWarning |
| `from telegramify_markdown.type import ...` | Works, re-exports from content | DeprecationWarning |
| `text_obj.content` | Works, returns MarkdownV2 string | DeprecationWarning |
| `file_obj.caption` | Works, returns MarkdownV2 string | DeprecationWarning |
| `ContentTypes.TEXT` | Works, alias for ContentType | No |

## Test plan

- [x] `pdm run test` — 177 tests pass
- [x] Manual verification of all compat shims with `-W all`
- [ ] Publish to PyPI as `1.0.0` (no `--pre` flag)

Closes #101