### PR TITLE
Fix configurable Mermaid image width

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This handles all MarkdownV2 escaping rules correctly (different escaping for nor
 
 ## ⚙️ Configuration
 
-Customize heading symbols, link symbols, and expandable citation behavior:
+Customize heading symbols, link symbols, expandable citation behavior, and Mermaid rendering:
 
 ```python
 from telegramify_markdown.config import get_runtime_config
@@ -191,6 +191,10 @@ cfg = get_runtime_config()
 cfg.markdown_symbol.heading_level_1 = "📌"
 cfg.markdown_symbol.link = "🔗"
 cfg.cite_expandable = True  # Long quotes become expandable_blockquote
+cfg.mermaid.width = 1280
+cfg.mermaid.scale = 2
+cfg.mermaid.theme = "default"
+cfg.mermaid.image_type = "webp"
 
 # For clean output without emoji heading prefixes:
 # cfg.markdown_symbol.heading_level_1 = ""
@@ -198,6 +202,8 @@ cfg.cite_expandable = True  # Long quotes become expandable_blockquote
 # cfg.markdown_symbol.heading_level_3 = ""
 # cfg.markdown_symbol.heading_level_4 = ""
 ```
+
+`telegramify()` picks up Mermaid settings from the runtime config. The default Mermaid width is `1000`.
 
 ## 📖 API Reference
 
@@ -355,6 +361,7 @@ from telegramify_markdown.config import get_runtime_config
 cfg = get_runtime_config()
 cfg.markdown_symbol.heading_level_1 = "📌"
 cfg.cite_expandable = True
+cfg.mermaid.width = 1280
 
 ## Critical rules
 - entities must be passed as list[dict] via [e.to_dict() for e in entities], NEVER as JSON string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegramify-markdown"
-version = "1.1.1"
+version = "1.1.2"
 description = "Convert Markdown to Telegram plain text + MessageEntity pairs"
 authors = [
     { name = "sudoskys", email = "coldlando@hotmail.com" },

--- a/src/telegramify_markdown/config.py
+++ b/src/telegramify_markdown/config.py
@@ -24,15 +24,28 @@ class Symbol:
         self.task_uncompleted: str = "\N{BALLOT BOX WITH CHECK}" # ☑️
 
 
+class Mermaid:
+    def __init__(self):
+        self.theme: str = "default"
+        self.width: int = 1000
+        self.scale: int = 2
+        self.image_type: str = "webp"
+
+
 @singleton
 class RenderConfig:
     def __init__(self):
         self._markdown_symbol = Symbol()
+        self._mermaid = Mermaid()
         self._cite_expandable = True
 
     @property
     def markdown_symbol(self) -> Symbol:
         return self._markdown_symbol
+
+    @property
+    def mermaid(self) -> Mermaid:
+        return self._mermaid
 
     @property
     def cite_expandable(self) -> bool:

--- a/src/telegramify_markdown/mermaid.py
+++ b/src/telegramify_markdown/mermaid.py
@@ -6,7 +6,9 @@ import zlib
 from io import BytesIO
 from typing import TYPE_CHECKING
 from typing import Union, Tuple
+from urllib.parse import urlencode
 
+from telegramify_markdown.config import get_runtime_config
 from telegramify_markdown.logger import logger
 
 if TYPE_CHECKING:
@@ -116,7 +118,7 @@ def generate_pako(graph_markdown: str, mermaid_config: MermaidConfig = None) -> 
     :return: The pako URL
     """
     if mermaid_config is None:
-        mermaid_config = MermaidConfig()
+        mermaid_config = MermaidConfig(theme=get_runtime_config().mermaid.theme)
     graph_data = {
         "code": graph_markdown,
         "mermaid": mermaid_config.__dict__
@@ -125,6 +127,19 @@ def generate_pako(graph_markdown: str, mermaid_config: MermaidConfig = None) -> 
     compressed_data = compress_to_deflate(json_bytes)
     base64_encoded = safe_base64_encode(compressed_data)
     return f"pako:{base64_encoded.decode('ascii')}"
+
+
+def _build_mermaid_ink_query() -> str:
+    """Build Mermaid Ink query parameters from runtime config."""
+    mermaid_config = get_runtime_config().mermaid
+    return urlencode(
+        {
+            "theme": mermaid_config.theme,
+            "width": mermaid_config.width,
+            "scale": mermaid_config.scale,
+            "type": mermaid_config.image_type,
+        }
+    )
 
 
 def b64_mermaid_url(diagram: str) -> str:
@@ -136,7 +151,7 @@ def b64_mermaid_url(diagram: str) -> str:
     :return: Link
     """
     diagram_encoded = safe_base64_encode(diagram.encode('utf8')).decode('ascii')
-    return f'https://mermaid.ink/img/{diagram_encoded}?theme=default&width=500&scale=2'
+    return f'https://mermaid.ink/img/{diagram_encoded}?{_build_mermaid_ink_query()}'
 
 
 def get_mermaid_live_url(graph_markdown: str) -> str:
@@ -156,7 +171,7 @@ def get_mermaid_ink_url(graph_markdown: str) -> str:
     :param graph_markdown: The Mermaid graph Markdown
     :return: Link
     """
-    return f'https://mermaid.ink/img/{generate_pako(graph_markdown)}?theme=default&width=500&scale=2&type=webp'
+    return f'https://mermaid.ink/img/{generate_pako(graph_markdown)}?{_build_mermaid_ink_query()}'
 
 
 async def render_mermaid(
@@ -184,5 +199,3 @@ def support_mermaid():
     except ImportError:
         return False
     return True
-
-

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -1,0 +1,74 @@
+import base64
+import json
+import unittest
+import zlib
+from urllib.parse import parse_qs, urlparse
+
+from telegramify_markdown.config import get_runtime_config
+from telegramify_markdown.mermaid import b64_mermaid_url, generate_pako, get_mermaid_ink_url
+
+
+def _decode_pako(payload: str) -> dict:
+    encoded = payload.removeprefix("pako:")
+    padded = encoded + "=" * (-len(encoded) % 4)
+    compressed = base64.urlsafe_b64decode(padded)
+    return json.loads(zlib.decompress(compressed).decode("ascii"))
+
+
+class MermaidConfigTest(unittest.TestCase):
+    def setUp(self):
+        self.cfg = get_runtime_config().mermaid
+        self._saved_theme = self.cfg.theme
+        self._saved_width = self.cfg.width
+        self._saved_scale = self.cfg.scale
+        self._saved_image_type = self.cfg.image_type
+
+    def tearDown(self):
+        self.cfg.theme = self._saved_theme
+        self.cfg.width = self._saved_width
+        self.cfg.scale = self._saved_scale
+        self.cfg.image_type = self._saved_image_type
+
+    def test_generate_pako_uses_runtime_theme_by_default(self):
+        self.cfg.theme = "neutral"
+
+        payload = generate_pako("graph TD\nA-->B")
+        decoded = _decode_pako(payload)
+
+        self.assertEqual(decoded["mermaid"]["theme"], "neutral")
+
+    def test_get_mermaid_ink_url_uses_runtime_config(self):
+        self.cfg.theme = "forest"
+        self.cfg.width = 1280
+        self.cfg.scale = 3
+        self.cfg.image_type = "png"
+
+        url = get_mermaid_ink_url("graph TD\nA-->B")
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        payload = parsed.path.removeprefix("/img/")
+        decoded = _decode_pako(payload)
+
+        self.assertEqual(query["theme"], ["forest"])
+        self.assertEqual(query["width"], ["1280"])
+        self.assertEqual(query["scale"], ["3"])
+        self.assertEqual(query["type"], ["png"])
+        self.assertEqual(decoded["mermaid"]["theme"], "forest")
+
+    def test_b64_mermaid_url_uses_runtime_config(self):
+        self.cfg.theme = "dark"
+        self.cfg.width = 900
+        self.cfg.scale = 4
+        self.cfg.image_type = "jpeg"
+
+        url = b64_mermaid_url("graph TD\nA-->B")
+        query = parse_qs(urlparse(url).query)
+
+        self.assertEqual(query["theme"], ["dark"])
+        self.assertEqual(query["width"], ["900"])
+        self.assertEqual(query["scale"], ["4"])
+        self.assertEqual(query["type"], ["jpeg"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the hard-coded Mermaid Ink width with runtime Mermaid rendering config
- bump the default Mermaid width from 500 to 1000 and expose width/scale/theme/image_type through `get_runtime_config()`
- add Mermaid config regression tests, update the README, and bump the package version to 1.1.2

## Testing
- pdm run test

Fixes #105