### PR TITLE
fix: preserve block spacing in MarkdownV2 conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ poetry add "telegramify-markdown[mermaid]"
 - If you are developing an *LLM application* or need to send potentially **super-long text** → use **`telegramify()`**
 - If you need to split `convert()` output manually → use **`split_entities()`**
 - If your middleware only supports `parse_mode="MarkdownV2"` (no `entities` parameter) → use **`markdownify()`**
+- If you need to split long MarkdownV2 output safely → use **`split_markdownv2()`**
 - If you need finer control over the reverse conversion → use **`entities_to_markdownv2()`**
 
 ### `convert()` — single message
@@ -165,6 +166,19 @@ bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
 
 `standardize()` is an alias for `markdownify()`, kept for 0.x compatibility.
 
+### `split_markdownv2()` — split MarkdownV2 safely
+
+If your middleware only supports `parse_mode="MarkdownV2"`, split by the rendered MarkdownV2 length, not only by the plain text length:
+
+```python
+from telegramify_markdown import convert, split_markdownv2
+
+text, entities = convert(long_markdown)
+
+for mdv2 in split_markdownv2(text, entities, max_utf16_len=4096):
+    bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
+```
+
 ### `entities_to_markdownv2()` — reverse conversion to MarkdownV2
 
 If you already have `(text, entities)` from `convert()` and need a MarkdownV2 string:
@@ -260,6 +274,11 @@ Useful when you already have `(text, entities)` from `convert()` and need a Mark
 | `text` | `str` | required | Plain text content |
 | `entities` | `list[MessageEntity] \| None` | `None` | Entity list (UTF-16 offsets) |
 
+### `split_markdownv2(text, entities=None, max_utf16_len=4096) -> list[str]`
+
+Split text + entities into Telegram MarkdownV2 strings within a rendered UTF-16 length limit.
+Use this instead of `split_entities()` when sending with `parse_mode="MarkdownV2"`.
+
 ### `MessageEntity`
 
 ```python
@@ -349,6 +368,12 @@ mdv2 = markdownify("**Bold** and `code`")
 bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
 # Use when your middleware only supports parse_mode, not entities parameter.
 # standardize() is an alias for markdownify().
+
+### split_markdownv2() — split rendered MarkdownV2 output
+from telegramify_markdown import convert, split_markdownv2
+text, entities = convert(long_md)
+for mdv2 in split_markdownv2(text, entities, max_utf16_len=4096):
+    bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
 
 ### entities_to_markdownv2() — reverse convert() output to MarkdownV2
 from telegramify_markdown import convert, entities_to_markdownv2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegramify-markdown"
-version = "1.1.2"
+version = "1.1.3"
 description = "Convert Markdown to Telegram plain text + MessageEntity pairs"
 authors = [
     { name = "sudoskys", email = "coldlando@hotmail.com" },

--- a/src/telegramify_markdown/__init__.py
+++ b/src/telegramify_markdown/__init__.py
@@ -9,12 +9,13 @@ from telegramify_markdown import config
 from telegramify_markdown.converter import convert as convert
 from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
 from telegramify_markdown.content import ContentType, ContentTypes, ContentTrace, File, Photo, Text
-from telegramify_markdown.mdv2 import entities_to_markdownv2
+from telegramify_markdown.mdv2 import entities_to_markdownv2, split_markdownv2
 
 __all__ = [
     "convert",
     "telegramify",
     "entities_to_markdownv2",
+    "split_markdownv2",
     "markdownify",
     "standardize",
     "config",

--- a/src/telegramify_markdown/converter.py
+++ b/src/telegramify_markdown/converter.py
@@ -171,15 +171,17 @@ class _EntityScope:
 class EventWalker:
     """Walks pyromark events and produces (text, entities, segments)."""
 
-    def __init__(self, config: RenderConfig) -> None:
+    def __init__(self, config: RenderConfig, source_markdown: str) -> None:
         self._buf = _TextBuffer()
         self._entity_stack: list[_EntityScope] = []
         self._entities: list[MessageEntity] = []
         self._segments: list[Segment] = []
         self._config = config
+        self._source_bytes = source_markdown.encode("utf-8")
 
         # Block-level state
         self._block_count: int = 0  # For paragraph spacing
+        self._last_block_end_source: int | None = None
         self._list_stack: list[int | None] = []  # None=unordered, int=next_number
         self._item_started: bool = False
         self._item_indent: str = ""  # 当前 item 的缩进，用于 task list marker 替换
@@ -196,6 +198,7 @@ class EventWalker:
         self._in_code_block: bool = False
         self._code_block_lang: str = ""
         self._code_block_parts: list[str] = []
+        self._code_block_start_source: int | None = None
 
         # Heading state
         self._in_heading: bool = False
@@ -218,22 +221,30 @@ class EventWalker:
     # -- Dispatch --------------------------------------------------------------
 
     def _handle_event(self, event) -> None:
+        source_range = None
+        if (
+            isinstance(event, tuple)
+            and len(event) == 2
+            and isinstance(event[1], dict)
+        ):
+            event, source_range = event
+
         if isinstance(event, str):
             if event == "SoftBreak":
                 self._on_soft_break()
             elif event == "HardBreak":
                 self._on_hard_break()
             elif event == "Rule":
-                self._on_rule()
+                self._on_rule(source_range)
             return
 
         if not isinstance(event, dict):
             return
 
         if "Start" in event:
-            self._on_start(event["Start"])
+            self._on_start(event["Start"], source_range)
         elif "End" in event:
-            self._on_end(event["End"])
+            self._on_end(event["End"], source_range)
         elif "Text" in event:
             self._on_text(event["Text"])
         elif "Code" in event:
@@ -241,7 +252,7 @@ class EventWalker:
         elif "InlineMath" in event:
             self._on_inline_math(event["InlineMath"])
         elif "DisplayMath" in event:
-            self._on_display_math(event["DisplayMath"])
+            self._on_display_math(event["DisplayMath"], source_range)
         elif "InlineHtml" in event:
             self._on_inline_html(event["InlineHtml"])
         elif "Html" in event:
@@ -253,7 +264,8 @@ class EventWalker:
 
     # -- Start events ----------------------------------------------------------
 
-    def _on_start(self, tag) -> None:
+    def _on_start(self, tag, source_range: dict[str, int] | None = None) -> None:
+        source_start = self._source_start(source_range)
         if tag == "Strong":
             self._push_entity("bold")
         elif tag == "Emphasis":
@@ -261,7 +273,7 @@ class EventWalker:
         elif tag == "Strikethrough":
             self._push_entity("strikethrough")
         elif tag == "Paragraph":
-            self._on_start_paragraph()
+            self._on_start_paragraph(source_start)
         elif tag == "Item":
             self._on_start_item()
         elif tag == "TableHead":
@@ -275,25 +287,26 @@ class EventWalker:
             pass
         elif isinstance(tag, dict):
             if "Heading" in tag:
-                self._on_start_heading(tag["Heading"])
+                self._on_start_heading(tag["Heading"], source_start)
             elif "CodeBlock" in tag:
-                self._on_start_code_block(tag["CodeBlock"])
+                self._on_start_code_block(tag["CodeBlock"], source_start)
             elif "BlockQuote" in tag:
-                self._on_start_blockquote()
+                self._on_start_blockquote(source_start)
             elif "Link" in tag:
                 self._on_start_link(tag["Link"])
             elif "Image" in tag:
                 self._on_start_image(tag["Image"])
             elif "List" in tag:
-                self._on_start_list(tag["List"])
+                self._on_start_list(tag["List"], source_start)
             elif "Table" in tag:
-                self._on_start_table(tag["Table"])
+                self._on_start_table(tag["Table"], source_start)
             elif "FootnoteDefinition" in tag:
-                self._ensure_block_spacing()
+                self._ensure_block_spacing(source_start)
 
     # -- End events ------------------------------------------------------------
 
-    def _on_end(self, tag) -> None:
+    def _on_end(self, tag, source_range: dict[str, int] | None = None) -> None:
+        source_end = self._source_end(source_range)
         if tag == "Strong":
             self._pop_entity("bold")
         elif tag == "Emphasis":
@@ -301,13 +314,13 @@ class EventWalker:
         elif tag == "Strikethrough":
             self._pop_entity("strikethrough")
         elif tag == "Paragraph":
-            self._on_end_paragraph()
+            self._on_end_paragraph(source_end)
         elif tag == "Item":
             self._on_end_item()
         elif tag == "CodeBlock":
-            self._on_end_code_block()
+            self._on_end_code_block(source_end)
         elif tag == "Table":
-            self._on_end_table()
+            self._on_end_table(source_end)
         elif tag == "TableCell":
             self._on_end_table_cell()
         elif tag == "TableRow":
@@ -322,11 +335,11 @@ class EventWalker:
             pass
         elif isinstance(tag, dict):
             if "Heading" in tag:
-                self._on_end_heading()
+                self._on_end_heading(source_end)
             elif "BlockQuote" in tag:
-                self._on_end_blockquote()
+                self._on_end_blockquote(source_end)
             elif "List" in tag:
-                self._on_end_list()
+                self._on_end_list(source_end)
 
     # -- Inline events ---------------------------------------------------------
 
@@ -354,10 +367,10 @@ class EventWalker:
             return
         self._buf.write("\n")
 
-    def _on_rule(self) -> None:
-        self._ensure_block_spacing()
+    def _on_rule(self, source_range: dict[str, int] | None = None) -> None:
+        self._ensure_block_spacing(self._source_start(source_range))
         self._buf.write("————————")
-        self._block_count += 1
+        self._mark_block_end(self._source_end(source_range))
 
     def _on_inline_code(self, code: str) -> None:
         if self._in_table_cell:
@@ -379,17 +392,17 @@ class EventWalker:
         if length > 0:
             self._entities.append(MessageEntity(type="code", offset=start, length=length))
 
-    def _on_display_math(self, math: str) -> None:
+    def _on_display_math(self, math: str, source_range: dict[str, int] | None = None) -> None:
         converted = math
         if _contains_latex_symbols(math):
             converted = _latex_helper.convert(math).strip()
-        self._ensure_block_spacing()
+        self._ensure_block_spacing(self._source_start(source_range))
         start = self._buf.utf16_offset
         self._buf.write(converted)
         length = self._buf.utf16_offset - start
         if length > 0:
             self._entities.append(MessageEntity(type="pre", offset=start, length=length))
-        self._block_count += 1
+        self._mark_block_end(self._source_end(source_range))
 
     def _on_inline_html(self, html: str) -> None:
         tag = html.strip().lower()
@@ -421,8 +434,10 @@ class EventWalker:
         "H6": ["italic"],
     }
 
-    def _on_start_heading(self, heading_data: dict) -> None:
-        self._ensure_block_spacing()
+    def _on_start_heading(
+        self, heading_data: dict, source_start: int | None = None
+    ) -> None:
+        self._ensure_block_spacing(source_start)
         level = heading_data["level"]
         symbol_map = {
             "H1": self._config.markdown_symbol.heading_level_1,
@@ -440,44 +455,45 @@ class EventWalker:
             self._push_entity(etype)
         self._in_heading = True
 
-    def _on_end_heading(self) -> None:
+    def _on_end_heading(self, source_end: int | None = None) -> None:
         for etype in reversed(self._heading_entities):
             self._pop_entity(etype)
         self._heading_entities = []
         self._in_heading = False
-        self._block_count += 1
+        self._mark_block_end(source_end)
 
     # -- Paragraph -------------------------------------------------------------
 
-    def _on_start_paragraph(self) -> None:
+    def _on_start_paragraph(self, source_start: int | None = None) -> None:
         if not self._list_stack:
-            self._ensure_block_spacing()
+            self._ensure_block_spacing(source_start)
 
-    def _on_end_paragraph(self) -> None:
+    def _on_end_paragraph(self, source_end: int | None = None) -> None:
         if not self._list_stack:
-            self._block_count += 1
+            self._mark_block_end(source_end)
         elif self._buf.trailing_newline_count() == 0:
             # loose list 中段落结束时写入换行，避免多段落粘连
             self._buf.write("\n")
 
     # -- Code block ------------------------------------------------------------
 
-    def _on_start_code_block(self, kind) -> None:
+    def _on_start_code_block(self, kind, source_start: int | None = None) -> None:
         self._in_code_block = True
         self._code_block_parts = []
+        self._code_block_start_source = source_start
         if isinstance(kind, dict) and "Fenced" in kind:
             self._code_block_lang = kind["Fenced"]
         else:
             self._code_block_lang = ""
 
-    def _on_end_code_block(self) -> None:
+    def _on_end_code_block(self, source_end: int | None = None) -> None:
         self._in_code_block = False
         raw_code = "".join(self._code_block_parts)
         # Strip single trailing newline (pulldown-cmark adds one)
         if raw_code.endswith("\n"):
             raw_code = raw_code[:-1]
 
-        self._ensure_block_spacing()
+        self._ensure_block_spacing(self._code_block_start_source)
 
         # Record segment
         seg_text_start = self._buf.py_offset
@@ -512,18 +528,19 @@ class EventWalker:
             )
         )
 
-        self._block_count += 1
+        self._mark_block_end(source_end)
         self._code_block_lang = ""
         self._code_block_parts = []
+        self._code_block_start_source = None
 
     # -- Blockquote ------------------------------------------------------------
 
-    def _on_start_blockquote(self) -> None:
-        self._ensure_block_spacing()
+    def _on_start_blockquote(self, source_start: int | None = None) -> None:
+        self._ensure_block_spacing(source_start)
         scope = _EntityScope("blockquote", self._buf.utf16_offset)
         self._blockquote_scopes.append(scope)
 
-    def _on_end_blockquote(self) -> None:
+    def _on_end_blockquote(self, source_end: int | None = None) -> None:
         if self._blockquote_scopes:
             scope = self._blockquote_scopes.pop()
             length = self._buf.utf16_offset - scope.start_offset
@@ -535,7 +552,7 @@ class EventWalker:
                         length=length,
                     )
                 )
-        self._block_count += 1
+        self._mark_block_end(source_end)
 
     # -- Links -----------------------------------------------------------------
 
@@ -561,9 +578,11 @@ class EventWalker:
 
     # -- Lists -----------------------------------------------------------------
 
-    def _on_start_list(self, start_number: int | None) -> None:
+    def _on_start_list(
+        self, start_number: int | None, source_start: int | None = None
+    ) -> None:
         if not self._list_stack:
-            self._ensure_block_spacing()
+            self._ensure_block_spacing(source_start)
         self._list_stack.append(start_number)
 
     def _on_start_item(self) -> None:
@@ -590,16 +609,16 @@ class EventWalker:
             self._buf.write("\n")
         self._item_started = False
 
-    def _on_end_list(self) -> None:
+    def _on_end_list(self, source_end: int | None = None) -> None:
         if self._list_stack:
             self._list_stack.pop()
         if not self._list_stack:
-            self._block_count += 1
+            self._mark_block_end(source_end)
 
     # -- Tables ----------------------------------------------------------------
 
-    def _on_start_table(self, alignments) -> None:
-        self._ensure_block_spacing()
+    def _on_start_table(self, alignments, source_start: int | None = None) -> None:
+        self._ensure_block_spacing(source_start)
         self._in_table = True
         self._table_alignments = alignments if isinstance(alignments, tuple) else ()
         self._table_rows = []
@@ -613,7 +632,7 @@ class EventWalker:
         self._table_rows.append(self._current_row)
         self._current_row = []
 
-    def _on_end_table(self) -> None:
+    def _on_end_table(self, source_end: int | None = None) -> None:
         self._in_table = False
         table_text = self._format_table(self._table_rows)
 
@@ -623,7 +642,7 @@ class EventWalker:
         if length > 0:
             self._entities.append(MessageEntity(type="pre", offset=start, length=length))
         self._table_rows = []
-        self._block_count += 1
+        self._mark_block_end(source_end)
 
     def _format_table(self, rows: list[list[str]]) -> str:
         if not rows:
@@ -688,11 +707,37 @@ class EventWalker:
             )
         )
 
-    def _ensure_block_spacing(self) -> None:
-        """Ensure a blank line (\\n\\n) between blocks, avoiding excess newlines."""
+    @staticmethod
+    def _source_start(source_range: dict[str, int] | None) -> int | None:
+        return source_range.get("start") if source_range else None
+
+    @staticmethod
+    def _source_end(source_range: dict[str, int] | None) -> int | None:
+        return source_range.get("end") if source_range else None
+
+    def _mark_block_end(self, source_end: int | None = None) -> None:
+        self._block_count += 1
+        if source_end is not None:
+            self._last_block_end_source = source_end
+
+    def _has_extra_blank_line(self, next_block_start: int) -> bool:
+        if self._last_block_end_source is None:
+            return False
+        if next_block_start <= self._last_block_end_source:
+            return False
+        gap = self._source_bytes[self._last_block_end_source:next_block_start]
+        return b"\n" in gap or b"\r" in gap
+
+    def _ensure_block_spacing(self, next_block_start: int | None = None) -> None:
+        """Ensure block spacing, preserving whether the source had an extra blank line."""
         if self._block_count > 0:
+            desired = 1
+            if next_block_start is None:
+                desired = 2
+            elif self._has_extra_blank_line(next_block_start):
+                desired = 2
             trailing = self._buf.trailing_newline_count()
-            needed = 2 - trailing
+            needed = desired - trailing
             if needed > 0:
                 self._buf.write("\n" * needed)
 
@@ -740,6 +785,6 @@ def convert_with_segments(
         preprocessed = _escape_latex(preprocessed)
     preprocessed = _preprocess_spoilers(preprocessed)
 
-    events = pyromark.events(preprocessed, options=STANDARD_OPTIONS)
-    walker = EventWalker(config)
+    events = pyromark.events_with_range(preprocessed, options=STANDARD_OPTIONS)
+    walker = EventWalker(config, preprocessed)
     return walker.walk(events)

--- a/src/telegramify_markdown/mdv2.py
+++ b/src/telegramify_markdown/mdv2.py
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from telegramify_markdown.entity import MessageEntity
+from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
 
 # MarkdownV2 普通文本需要转义的 20 个字符
 _MDV2_ESCAPE_CHARS = frozenset("_*[]()~`>#+-=|{}.!\\")
@@ -240,6 +240,52 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
         parts.append("||")
 
     return "".join(parts)
+
+
+def split_markdownv2(
+    text: str,
+    entities: list[MessageEntity] | None = None,
+    max_utf16_len: int = 4096,
+) -> list[str]:
+    """Split text/entities into MarkdownV2 strings that fit Telegram's length limit.
+
+    ``split_entities()`` limits the plain text length. MarkdownV2 adds escapes and
+    formatting markers, so a plain-text chunk near 4096 code units can still become
+    too long after ``entities_to_markdownv2()``. This helper splits by the rendered
+    MarkdownV2 length instead.
+    """
+    if max_utf16_len <= 0:
+        raise ValueError("max_utf16_len must be greater than 0")
+    if not text:
+        return []
+
+    pending = split_entities(text, list(entities or []), max_utf16_len)
+    chunks: list[str] = []
+
+    while pending:
+        chunk_text, chunk_entities = pending.pop(0)
+        rendered = entities_to_markdownv2(chunk_text, chunk_entities)
+        if utf16_len(rendered) <= max_utf16_len:
+            chunks.append(rendered)
+            continue
+
+        plain_len = utf16_len(chunk_text)
+        if plain_len <= 1:
+            raise ValueError(
+                "A single text unit renders longer than max_utf16_len in MarkdownV2"
+            )
+
+        sub_limit = max(1, plain_len // 2)
+        sub_chunks = split_entities(chunk_text, chunk_entities, sub_limit)
+        if len(sub_chunks) == 1:
+            sub_limit = max(1, plain_len - 1)
+            sub_chunks = split_entities(chunk_text, chunk_entities, sub_limit)
+        if len(sub_chunks) == 1:
+            raise ValueError("Unable to split MarkdownV2 output within max_utf16_len")
+
+        pending = sub_chunks + pending
+
+    return chunks
 
 
 def _get_open_tag(ent: MessageEntity) -> str:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -189,6 +189,25 @@ class BlockquoteTest(unittest.TestCase):
         bq = _find_entity(entities, "expandable_blockquote")
         self.assertIsNotNone(bq)
 
+    def test_blockquote_before_code_block_without_blank_line(self):
+        md = ">Text example 1\n```py\nSecond line example\nThird line example\n```"
+        text, entities = convert(md, latex_escape=False)
+        self.assertEqual(text, "Text example 1\nSecond line example\nThird line example")
+        bq = _find_entity(entities, "blockquote")
+        pre = _find_entity(entities, "pre")
+        self.assertIsNotNone(bq)
+        self.assertIsNotNone(pre)
+        self.assertEqual(bq.length, 14)
+        self.assertEqual(pre.offset, 15)
+
+    def test_blockquote_before_code_block_with_blank_line(self):
+        md = ">Text example 1\n\n```py\nSecond line example\nThird line example\n```"
+        text, entities = convert(md, latex_escape=False)
+        self.assertEqual(text, "Text example 1\n\nSecond line example\nThird line example")
+        pre = _find_entity(entities, "pre")
+        self.assertIsNotNone(pre)
+        self.assertEqual(pre.offset, 16)
+
 
 class TableTest(unittest.TestCase):
     def test_simple_table(self):

--- a/tests/test_mdv2.py
+++ b/tests/test_mdv2.py
@@ -1,5 +1,6 @@
 """tests for entities_to_markdownv2"""
 
+import pathlib
 import unittest
 
 from telegramify_markdown.entity import MessageEntity, utf16_len
@@ -8,7 +9,10 @@ from telegramify_markdown.mdv2 import (
     _escape_markdownv2,
     _escape_url,
     entities_to_markdownv2,
+    split_markdownv2,
 )
+
+TESTS_DIR = pathlib.Path(__file__).parent
 
 
 # ── 第一层：基础转义 ──
@@ -258,6 +262,26 @@ class NoEntitiesTest(unittest.TestCase):
         self.assertEqual(result, "hello")
 
 
+class SplitMarkdownV2Test(unittest.TestCase):
+    def test_split_respects_rendered_limit_after_escaping(self):
+        text = ("a.b! " * 30).strip()
+        chunks = split_markdownv2(text, [], max_utf16_len=20)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(utf16_len(chunk), 20)
+        self.assertEqual("".join(chunks), entities_to_markdownv2(text, []))
+
+    def test_split_exp2_respects_telegram_limit(self):
+        from telegramify_markdown import convert
+
+        md = (TESTS_DIR / "exp2.md").read_text(encoding="utf-8")
+        text, entities = convert(md)
+        chunks = split_markdownv2(text, entities, max_utf16_len=4096)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(utf16_len(chunk), 4096)
+
+
 class EmptyTextTest(unittest.TestCase):
     def test_empty_text(self):
         result = entities_to_markdownv2("", [])
@@ -295,6 +319,26 @@ class RoundtripTest(unittest.TestCase):
         result = entities_to_markdownv2(text, entities)
         self.assertIn("[", result)
         self.assertIn("https://example.com", result)
+
+    def test_markdownify_blockquote_before_code_block_without_blank_line(self):
+        from telegramify_markdown import markdownify
+
+        md = ">Text example 1\n```py\nSecond line example\nThird line example\n```"
+        result = markdownify(md, latex_escape=False)
+        self.assertEqual(
+            result,
+            ">Text example 1\n```py\nSecond line example\nThird line example\n```",
+        )
+
+    def test_markdownify_blockquote_before_code_block_with_blank_line(self):
+        from telegramify_markdown import markdownify
+
+        md = ">Text example 1\n\n```py\nSecond line example\nThird line example\n```"
+        result = markdownify(md, latex_escape=False)
+        self.assertEqual(
+            result,
+            ">Text example 1\n\n```py\nSecond line example\nThird line example\n```",
+        )
 
 
 class SpecialCharInEntityTest(unittest.TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -175,25 +175,21 @@ class TelegramMarkdownV2ServerTest(unittest.TestCase):
 
     def test_mdv2_exp1(self):
         """convert(exp1.md) → entities_to_markdownv2 的输出通过 Telegram MarkdownV2 验证。"""
-        from telegramify_markdown import convert, entities_to_markdownv2, split_entities
+        from telegramify_markdown import convert, split_markdownv2
 
         md = (TESTS_DIR / "exp1.md").read_text(encoding="utf-8")
         text, entities = convert(md)
-        chunks = split_entities(text, entities, 4096)
-        for chunk_text, chunk_entities in chunks:
-            mdv2 = entities_to_markdownv2(chunk_text, chunk_entities)
+        for mdv2 in split_markdownv2(text, entities, 4096):
             result = _send_mdv2(self.bot, self.chat_id, mdv2)
             self.assertTrue(result, f"MarkdownV2 rejected by Telegram:\n{mdv2[:200]}")
 
     def test_mdv2_exp2(self):
         """convert(exp2.md) → entities_to_markdownv2 的输出通过 Telegram MarkdownV2 验证。"""
-        from telegramify_markdown import convert, entities_to_markdownv2, split_entities
+        from telegramify_markdown import convert, split_markdownv2
 
         md = (TESTS_DIR / "exp2.md").read_text(encoding="utf-8")
         text, entities = convert(md)
-        chunks = split_entities(text, entities, 4096)
-        for chunk_text, chunk_entities in chunks:
-            mdv2 = entities_to_markdownv2(chunk_text, chunk_entities)
+        for mdv2 in split_markdownv2(text, entities, 4096):
             result = _send_mdv2(self.bot, self.chat_id, mdv2)
             self.assertTrue(result, f"MarkdownV2 rejected by Telegram:\n{mdv2[:200]}")
 


### PR DESCRIPTION
## Summary
- Fixes issue #107 by preserving source block spacing between blockquotes and following code blocks.
- Adds `split_markdownv2()` for parse-mode users so rendered MarkdownV2 chunks stay within Telegram's length limit, and bumps the package version to `1.1.3`.

## Why
- The converter previously normalized every adjacent block boundary to a blank line, which inserted an extra `\n` not present in the source.
- `split_entities()` is correct for Telegram entity sends, but MarkdownV2 parse-mode sends need a rendered-length splitter because escaping and markers add characters.

## Scope
- In: block spacing in `convert()`/`markdownify()`, MarkdownV2-aware splitting, tests, README API docs, version bump.
- Out: changing Telegram entity-mode splitting semantics or Mermaid rendering behavior.

## Verification
```bash
pdm run test
TELEGRAM_BOT_TOKEN=<local token> pdm run python -m unittest tests.test_server
```

Key output:
```text
Ran 190 tests in 2.128s
OK (skipped=7)

Ran 7 tests in 25.533s
OK
```

## Risks
- Low risk: spacing now depends on `pyromark.events_with_range()` source ranges, which are already exposed by the parser used by this package.
- `split_markdownv2()` can raise `ValueError` if one indivisible entity renders longer than the Telegram limit, which is preferable to silently sending an invalid request.

## Docs
- [x] Related docs updated
- [x] ADR / changelog not applicable
- [x] ADR index not applicable

Closes #107.
