### PR TITLE
feat: add horizontal_rule to config

### DIFF
--- a/src/telegramify_markdown/config.py
+++ b/src/telegramify_markdown/config.py
@@ -22,6 +22,7 @@ class Symbol:
         self.link: str = "\N{LINK SYMBOL}"                       # 🔗
         self.task_completed: str = "\N{WHITE HEAVY CHECK MARK}"  # ✅
         self.task_uncompleted: str = "\N{BALLOT BOX WITH CHECK}" # ☑️
+        self.horizontal_rule: str = "————————"
 
 
 class Mermaid:

--- a/src/telegramify_markdown/converter.py
+++ b/src/telegramify_markdown/converter.py
@@ -369,7 +369,7 @@ class EventWalker:
 
     def _on_rule(self, source_range: dict[str, int] | None = None) -> None:
         self._ensure_block_spacing(self._source_start(source_range))
-        self._buf.write("————————")
+        self._buf.write(self._config.markdown_symbol.horizontal_rule)
         self._mark_block_end(self._source_end(source_range))
 
     def _on_inline_code(self, code: str) -> None:


### PR DESCRIPTION
## Summary
- Replace the hard-coded horizontal rule string with the runtime rendering config.

## Testing
- [x] `pdm run test` — 190 tests pass