### PR TITLE
fix: skip whitespace-only split chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ for chunk_text, chunk_entities in split_entities(text, entities, max_utf16_len=4
     )
 ```
 
+`split_entities()` omits empty and whitespace-only chunks because Telegram rejects them as empty messages.
+
 ### `markdownify()` — direct Markdown to MarkdownV2
 
 If your middleware only supports `parse_mode="MarkdownV2"` and cannot pass entities, use `markdownify()` for a
@@ -248,7 +250,8 @@ Returns an ordered list of `Text`, `File`, or `Photo` objects.
 ### `split_entities(text, entities, max_utf16_len) -> list[tuple[str, list[MessageEntity]]]`
 
 Split text + entities into chunks within a UTF-16 length limit. Splits at newline boundaries;
-entities spanning a split point are clipped into both chunks.
+entities spanning a split point are clipped into both chunks. Empty and whitespace-only
+chunks are omitted because Telegram rejects them as empty messages.
 
 ### `markdownify(content, *, latex_escape=True) -> str`
 

--- a/src/telegramify_markdown/entity.py
+++ b/src/telegramify_markdown/entity.py
@@ -80,10 +80,13 @@ def split_entities(
     """Split (text, entities) into chunks not exceeding max_utf16_len UTF-16 code units.
 
     Tries to split at newline boundaries. Entities that span a split boundary
-    are clipped into both chunks.
+    are clipped into both chunks. Whitespace-only chunks are omitted because
+    Telegram rejects them as empty message text.
     """
     total = utf16_len(text)
     if total <= max_utf16_len:
+        if not text.strip():
+            return []
         return [(text, list(entities))]
 
     offsets = _build_utf16_offset_table(text)
@@ -162,6 +165,7 @@ def split_entities(
                 )
             )
 
-        result.append((chunk_text, chunk_entities))
+        if chunk_text.strip():
+            result.append((chunk_text, chunk_entities))
 
     return result

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -80,8 +80,24 @@ class SplitEntitiesTest(unittest.TestCase):
 
     def test_empty_text(self):
         result = split_entities("", [], max_utf16_len=100)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0], ("", []))
+        self.assertEqual(result, [])
+
+    def test_whitespace_only_text_is_omitted_without_splitting(self):
+        result = split_entities("\n\n", [], max_utf16_len=100)
+        self.assertEqual(result, [])
+
+    def test_whitespace_only_chunks_are_omitted_after_splitting(self):
+        result = split_entities("\n" * 5000, [], max_utf16_len=4096)
+        self.assertEqual(result, [])
+
+    def test_omits_whitespace_only_chunk_but_keeps_content_chunk(self):
+        text = ("\n" * 5000) + "hello"
+        entities = [MessageEntity(type="bold", offset=5000, length=5)]
+        result = split_entities(text, entities, max_utf16_len=4096)
+        self.assertEqual(
+            result,
+            [("\n" * 904 + "hello", [MessageEntity(type="bold", offset=904, length=5)])],
+        )
 
     def test_split_at_newline(self):
         text = "aaa\nbbb\nccc"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,7 +35,11 @@ def _send_text_with_entities(bot, chat_id, text: str, entities_dicts: list[dict]
         )
     except Exception as e:
         err = str(e)
-        if "send messages to bots" in err or "bot can't send messages to bots" in err:
+        if (
+            "send messages to bots" in err
+            or "bot can't send messages to bots" in err
+            or "bot can't send messages to the bot" in err
+        ):
             return True
         # Re-raise unexpected errors (e.g. entity validation failures)
         raise
@@ -152,7 +156,11 @@ def _send_mdv2(bot, chat_id, mdv2_text: str) -> bool:
         )
     except Exception as e:
         err = str(e)
-        if "send messages to bots" in err or "bot can't send messages to bots" in err:
+        if (
+            "send messages to bots" in err
+            or "bot can't send messages to bots" in err
+            or "bot can't send messages to the bot" in err
+        ):
             return True
         raise
     return False


### PR DESCRIPTION
## Summary
- Fixes #112.
- Make split_entities omit empty and whitespace-only chunks so callers do not pass Telegram message text that the Bot API rejects as empty.
- Preserve entity clipping for retained chunks and document the sendable-chunk behavior in the README.
- Update Telegram integration test helpers to accept the current equivalent 'the bot' rejection wording after message validation succeeds.

## Root Cause
split_entities returned immediately for text within the UTF-16 limit and appended every generated chunk after splitting. That allowed inputs like '\n\n' or '\n' * 5000 to produce whitespace-only chunks, which Telegram rejects as empty message text.

## Preflight
- Symptom: split_entities can produce whitespace-only chunks that fail Telegram sendMessage with 400 message text is empty.
- Core concept: sendable split chunk.
- Authority points: src/telegramify_markdown/entity.py split_entities owns public splitting; src/telegramify_markdown/pipeline.py _append_text_chunks consumes split_entities before Text output; src/telegramify_markdown/mdv2.py split_markdownv2 also reuses split_entities for rendered MarkdownV2 splitting.
- Change locus: src/telegramify_markdown/entity.py, same layer as the split chunk authority.
- Falsification: checked pipeline and MarkdownV2 callers before editing; the bug was not confined to one downstream sender.

## Verification
- pdm run python -m unittest tests.test_entity tests.test_mdv2 tests.test_pipeline
- pdm run python - <<'PY'
from telegramify_markdown import split_entities
for text in ['\n\n', '\n' * 5000, ('\n' * 5000) + 'hello']:
    chunks = split_entities(text, [], 4096)
    print(len(chunks), [bool(chunk_text.strip()) for chunk_text, _ in chunks])
PY
- git diff --check
- pdm run test (195 tests passed, including Telegram integration tests)