### PR TITLE
feat: add streaming draft support (ADR-002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ poetry add "telegramify-markdown[mermaid]"
 
 - If you just want to send *static text* and don't want to worry about formatting → use **`convert()`**
 - If you are developing an *LLM application* or need to send potentially **super-long text** → use **`telegramify()`**
+- If you need **streaming output** (token-by-token, like ChatGPT typing) → use **`DraftStream`** (private) or **`EditStream`** (group)
 - If you need to split `convert()` output manually → use **`split_entities()`**
 - If your middleware only supports `parse_mode="MarkdownV2"` (no `entities` parameter) → use **`markdownify()`**
 - If you need to split long MarkdownV2 output safely → use **`split_markdownv2()`**
@@ -151,6 +152,53 @@ TELEGRAM_BOT_TOKEN=... TELEGRAM_CHAT_ID=... pdm run test-live-rich
 
 The test sends a real `sendRichMessage` request and requires Telegram to return
 `Message.rich_message`.
+
+### `DraftStream` / `EditStream` — streaming LLM output (Bot API 9.3+)
+
+For token-by-token LLM output, `DraftStream` sends intermediate drafts via
+`sendMessageDraft` / `sendRichMessageDraft`, then finalizes with the complete
+message. Works in private chats. For group chats (no draft API), `EditStream`
+sends then edits the message.
+
+```python
+import asyncio
+from telegramify_markdown.stream import DraftStream
+
+async def stream_response(chat_id, token, llm_tokens):
+    async def send_draft(payload):
+        # Call sendRichMessageDraft with payload.rich_message.to_dict()
+        ...
+
+    async def send_final(payload):
+        # Call sendRichMessage with payload.rich_message.to_dict()
+        ...
+
+    async with DraftStream(
+        send_draft=send_draft,
+        send_final=send_final,
+        mode="rich",           # "rich" | "entity"
+        interval=0.3,          # seconds between draft updates
+        thinking_delay=0.5,    # show "Thinking..." before first content
+        keepalive_timeout=25.0,  # prevent draft expiry
+    ) as stream:
+        async for tok in llm_tokens:
+            stream.feed(tok)
+```
+
+For group/channel chats (draft API unavailable):
+
+```python
+from telegramify_markdown.stream import EditStream
+
+async with EditStream(
+    send_message=my_send_fn,   # async (payload) -> message_id
+    edit_message=my_edit_fn,   # async (message_id, payload) -> None
+    mode="rich",
+    interval=1.0,              # >= 1.0s enforced (Telegram edit rate limit)
+) as stream:
+    async for tok in llm_tokens:
+        stream.feed(tok)
+```
 
 ### `telegramify()` — long messages, code files, diagrams
 
@@ -457,92 +505,15 @@ Returns the length of a string in UTF-16 code units (what Telegram uses for offs
 
 ## 🤖 For AI Coding Assistants
 
-Copy this block into your AI assistant's context (e.g. `CLAUDE.md`, Cursor Rules, etc.) to get
-accurate code generation for telegramify-markdown:
+This project provides [`llms.txt`](llms.txt) and [`llms-full.txt`](llms-full.txt) for AI assistant context.
+Copy the relevant file into your assistant's context (e.g. `CLAUDE.md`, Cursor Rules) for
+accurate code generation.
 
-<details>
-<summary>Click to expand context block</summary>
-
-```markdown
-# telegramify-markdown integration guide
-
-## Install
-uv add telegramify-markdown  # or: pip install telegramify-markdown
-
-## API (v1.0.0+) — outputs plain text + MessageEntity, NOT MarkdownV2 strings
-
-### convert() — sync, single message
-from telegramify_markdown import convert
-text, entities = convert("**bold** and _italic_")
-bot.send_message(chat_id, text, entities=[e.to_dict() for e in entities])
-# Do NOT set parse_mode — entities replace it entirely.
-
-### telegramify() — async, auto-splits long text, extracts code blocks as files
-from telegramify_markdown import telegramify
-from telegramify_markdown.content import ContentType
-results = await telegramify(md, max_message_length=4090)
-for item in results:
-    if item.content_type == ContentType.TEXT:
-        bot.send_message(chat_id, item.text, entities=[e.to_dict() for e in item.entities])
-    elif item.content_type == ContentType.FILE:
-        bot.send_document(chat_id, (item.file_name, item.file_data))
-    elif item.content_type == ContentType.PHOTO:
-        bot.send_photo(chat_id, (item.file_name, item.file_data))
-
-### split_entities() — manual splitting for convert() output
-from telegramify_markdown import convert, split_entities
-text, entities = convert(long_md)
-for chunk_text, chunk_entities in split_entities(text, entities, max_utf16_len=4096):
-    bot.send_message(chat_id, chunk_text, entities=[e.to_dict() for e in chunk_entities])
-
-### markdownify() — direct Markdown to MarkdownV2 string
-from telegramify_markdown import markdownify
-mdv2 = markdownify("**Bold** and `code`")
-bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
-# Use when your middleware only supports parse_mode, not entities parameter.
-# standardize() is an alias for markdownify().
-
-### split_markdownv2() — split rendered MarkdownV2 output
-from telegramify_markdown import convert, split_markdownv2
-text, entities = convert(long_md)
-for mdv2 in split_markdownv2(text, entities, max_utf16_len=4096):
-    bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
-
-### entities_to_markdownv2() — reverse convert() output to MarkdownV2
-from telegramify_markdown import convert, entities_to_markdownv2
-text, entities = convert("**Bold** and `code`")
-mdv2 = entities_to_markdownv2(text, entities)
-bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
-
-### richify() — Telegram Bot API 10.1 Rich Message payload
-from telegramify_markdown import richify
-rich = richify("# Title\n\n| A | B |\n|---|---|\n| 1 | 2 |")
-payload = {"chat_id": chat_id, "rich_message": rich.to_dict()}
-
-### telegramify_rich() — split long Rich Messages automatically
-from telegramify_markdown import telegramify_rich
-items = telegramify_rich(very_long_md)
-for item in items:
-    payload = {"chat_id": chat_id, "rich_message": item.to_dict()}
-    # send via sendRichMessage
-
-### Configuration
-from telegramify_markdown.config import get_runtime_config
-cfg = get_runtime_config()
-cfg.markdown_symbol.heading_level_1 = "📌"
-cfg.cite_expandable = True
-cfg.mermaid.width = 1280
-
-## Critical rules
-- entities must be passed as list[dict] via [e.to_dict() for e in entities], NEVER as JSON string
-- NEVER set parse_mode when sending with entities — they are mutually exclusive
-- All entity offsets are UTF-16 code units. Use utf16_len() to measure text length.
-- richify() returns an InputRichMessage payload for sendRichMessage, not text + entities
-- telegramify_rich() splits long Rich Messages at block boundaries; each chunk is valid HTML
-- Requires Python 3.10+
-```
-
-</details>
+Critical rules:
+- Pass entities as `[e.to_dict() for e in entities]` — never as JSON string
+- Never set `parse_mode` when sending with entities — they are mutually exclusive
+- `richify()` returns `InputRichMessage` for `sendRichMessage`, not text + entities
+- Entity offsets are UTF-16 code units. Use `utf16_len()` to measure.
 
 ## 🧸 Acknowledgement
 

--- a/docs/adr/002-streaming-draft-support.md
+++ b/docs/adr/002-streaming-draft-support.md
@@ -1,0 +1,582 @@
+---
+id: ADR-002
+title: Streaming draft support via sendMessageDraft / sendRichMessageDraft
+status: Accepted
+date: 2026-06-13
+author: Lilith
+supersedes: []
+superseded_by: null
+prds:
+  - rich-message
+summary: Two-layer async streaming architecture — a protocol-agnostic StreamCore (buffer + throttle + concurrency) composed with strategy facades (DraftStream, EditStream) that inject rendering and Telegram transport.
+---
+
+# ADR-002: Streaming draft support via sendMessageDraft / sendRichMessageDraft
+
+> **Status**: Accepted.
+
+## Context
+
+LLM bots produce output token-by-token. Users expect to see partial results as
+the model generates. Telegram Bot API 9.3+ introduced `sendMessageDraft` (plain
+text drafts) and Bot API 10.1 added `sendRichMessageDraft` (rich message drafts)
+specifically for this use case.
+
+This library already provides the conversion pipeline (Markdown → Entity and
+Markdown → Rich HTML). Streaming draft support adds a **temporal dimension** on
+top of the existing spatial pipeline: the same conversion runs repeatedly on a
+growing input buffer, with throttled delivery of intermediate results.
+
+### Key constraints
+
+| Constraint | Source | Value |
+|---|---|---|
+| Draft only in private chats | Telegram API | Group/channel must use `editMessageText` fallback |
+| Draft expiry | Community observation (not officially documented) | ~30 seconds without update → draft disappears |
+| Draft ID must be nonzero | Telegram API | Caller-chosen identifier; same ID animates updates |
+| Empty text shows "Thinking…" | Bot API 10.1 | `sendMessageDraft` with empty text; unavailable in 9.3–10.0 |
+| Draft text limit (Entity mode) | Telegram API | 0–4096 characters after entity parsing |
+| Re-parse cost | Benchmarked locally | ~0.18ms/2KB, ~0.5ms/10KB, ~2.5ms/50KB (linear growth, pyromark + walker) |
+| pyromark tolerance | Verified locally | Gracefully handles incomplete Markdown (unclosed fences, partial emphasis become text) |
+| Throttle recommendation | Community practice | 2–5 updates/second avoids client lag; draft API less restricted than `editMessageText` |
+
+### Why re-parse entire buffer (not incremental)
+
+Incremental Markdown parsing is fragile: a backtick at position 50 can
+retroactively change the meaning of everything after position 10. pyromark does
+not expose an incremental API. Given 0.18ms per parse for 2KB and ~0.5ms for
+10KB, re-parsing the full accumulated buffer on each throttled update is
+negligible compared to network RTT (~50–200ms) and Telegram's processing time.
+
+For large LLM outputs (~50KB), re-parse cost is ~2.5ms — still well within a
+300ms throttle interval. If a future benchmark shows parse+render exceeding
+`interval / 2`, the implementation should log a warning and suggest increasing
+the interval. For documents under 100KB, re-parse is not the bottleneck.
+
+## Decision
+
+Provide a **two-layer async streaming architecture**:
+
+1. **`StreamCore`** (mechanism layer) — a minimal, protocol-agnostic throttled
+   buffer that accepts tokens, renders via an injected function, emits snapshots
+   via an injected callback, and finalizes via an injected callback. It knows
+   nothing about Telegram, Markdown, Rich HTML, or drafts.
+
+2. **`DraftStream` / `EditStream`** (strategy layer) — thin facades that
+   assemble `StreamCore` with the appropriate render function (`convert()` or
+   `richify()`), emit callback (draft or edit), and Telegram-specific policies
+   (thinking delay, draft ID, sliding window).
+
+This separation ensures the concurrency model, throttle logic, and state machine
+are implemented and tested exactly once. New transport modes (webhook push,
+WebSocket, future Telegram APIs) only require a new facade — never a change to
+the core.
+
+### Architecture diagram
+
+```text
+┌────────────────────────────────────────────────────────────┐
+│  Strategy Layer (user-facing)                              │
+│                                                            │
+│  DraftStream(mode, draft_id, thinking_delay, ...)         │
+│    └─ assembles: render=richify|convert                    │
+│                  emit=send_draft callback                  │
+│                  finalize=send_final callback              │
+│                  window=sliding_window_rich|entity         │
+│                                                            │
+│  EditStream(mode, ...)                                     │
+│    └─ assembles: render=richify|convert                    │
+│                  emit=edit_message callback                │
+│                  finalize=send_message callback            │
+│                  interval lower-bound=1.0s                 │
+│                                                            │
+└──────────────────────────┬─────────────────────────────────┘
+                           │ injects
+┌──────────────────────────▼─────────────────────────────────┐
+│  StreamCore (mechanism layer)                              │
+│                                                            │
+│  Parameters:                                               │
+│    render: Callable[[str], T]     # buffer → payload       │
+│    emit:   Callable[[T], Awaitable]  # snapshot delivery   │
+│    finalize: Callable[[T], Awaitable]  # final delivery    │
+│    interval: float                # throttle period        │
+│    keepalive_timeout: float       # anti-expiry            │
+│                                                            │
+│  State machine: IDLE → ACTIVE → DONE                      │
+│  Concurrency: _sending guard, timer cancel, drain-await   │
+│  API: feed(), consume(), finish(), cancel()               │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Why two layers (not one)
+
+| Monolithic (rejected) | Layered (chosen) |
+|---|---|
+| Core class knows about `mode="rich"\|"entity"` | Core receives opaque `render` callable |
+| Adding group-chat edit requires `if fallback` branches in core | `EditStream` is a separate facade with different `emit` and `interval` |
+| Testing throttle/concurrency requires mocking Telegram payloads | Core tests use trivial `render=str.upper`, `emit=mock_coro` |
+| New transport = modify core class | New transport = new facade (one file) |
+
+### StreamCore detail
+
+```python
+class StreamCore(Generic[T]):
+    """Protocol-agnostic throttled streaming buffer."""
+
+    def __init__(
+        self,
+        render: Callable[[str], T],
+        emit: Callable[[T], Awaitable[None]],
+        finalize: Callable[[T], Awaitable[None]],
+        interval: float = 0.3,
+        keepalive_timeout: float = 25.0,
+        on_cancel: Callable[[], Awaitable[None]] | None = None,
+    ): ...
+
+    def feed(self, token: str) -> None: ...
+    async def consume(self, tokens: AsyncIterator[str]) -> None: ...
+    async def finish(self) -> None: ...
+    async def cancel(self) -> None: ...
+```
+
+**State machine** (3 states):
+
+```text
+┌────────┐   feed()/consume()   ┌────────┐   finish()/cancel()   ┌────────┐
+│  IDLE  │─────────────────────▶│ ACTIVE │───────────────────────▶│  DONE  │
+└────────┘                      └────────┘                        └────────┘
+```
+
+- **IDLE**: No tokens received. No timer running. No API calls.
+- **ACTIVE**: Buffer growing, timer running, periodic `emit()` on throttled
+  schedule. Includes "first emit" behavior (thinking indicator) as a special
+  case of the first `emit()` call — not a separate state.
+- **DONE**: Terminal. `finish()` called `finalize()` once; or `cancel()` called
+  `on_cancel()`. Timer stopped. Further `feed()` raises `RuntimeError`.
+
+### DraftStream (strategy facade)
+
+```python
+from telegramify_markdown.stream import DraftStream
+
+async with DraftStream(
+    send_draft=my_send_draft_fn,     # async (payload) -> None
+    send_final=my_send_final_fn,     # async (payload) -> None
+    mode="rich",                     # "rich" | "entity"
+    draft_id=None,                   # None = auto-generate; or nonzero int
+    interval=0.3,                    # seconds between draft updates
+    thinking_delay=0.5,              # seconds before first substantive draft
+    keepalive_timeout=25.0,          # seconds without tokens before keepalive
+    cancel_clears_draft=True,        # send empty draft on cancel
+) as stream:
+    # Option A: manual feed
+    async for token in llm_response:
+        stream.feed(token)
+
+    # Option B: convenience consume
+    # await stream.consume(llm_response)
+```
+
+`DraftStream` internally:
+1. Selects `render` = `richify` or `convert` based on `mode`.
+2. Wraps `render` with sliding-window truncation (trailing 4096 chars for entity,
+   trailing blocks within 32KB for rich).
+3. Wraps `send_draft` as `emit` (prepending thinking-delay logic on first call).
+4. Wraps `send_final` as `finalize` (calling `convert()` or `richify()` for
+   single-message rendering). Note: the full splitting pipeline
+   (`telegramify()` / `telegramify_rich()`) returns multiple content items —
+   multi-message orchestration is the caller's responsibility, not the stream's.
+5. Passes `on_cancel` = empty-draft sender when `cancel_clears_draft=True`.
+6. Delegates everything else to `StreamCore`.
+
+When `draft_id=None`, auto-generates a unique nonzero ID via
+`hash(id(self)) & 0x7FFFFFFF | 1`. Callers who need to correlate draft IDs
+across streams can pass an explicit value.
+
+### EditStream (group-chat facade)
+
+```python
+from telegramify_markdown.stream import EditStream
+
+async with EditStream(
+    send_message=my_send_fn,         # async (payload) -> message_id
+    edit_message=my_edit_fn,         # async (message_id, payload) -> None
+    mode="rich",
+    interval=1.0,                    # ≥1.0s enforced (Telegram edit limit)
+) as stream:
+    await stream.consume(llm_response)
+```
+
+`EditStream` internally:
+1. On first emit, calls `send_message` to create the placeholder, stores the
+   returned `message_id`.
+2. Subsequent emits call `edit_message(message_id, payload)`.
+3. Enforces `interval >= 1.0` (Telegram's edit rate limit).
+4. Finalize = one last `edit_message` with the complete rendered content.
+
+### Throttle and debounce strategy (StreamCore)
+
+```text
+token arrives → mark buffer dirty
+                     ↓
+           timer fires (every `interval` ms)
+                     ↓
+           if dirty AND NOT _sending:
+               payload = render(buffer)
+               _sending = True
+               try: await emit(payload)
+               finally: _sending = False
+               clear dirty flag
+               reset keepalive timer
+```
+
+- **Minimum interval**: 200ms for DraftStream (configurable). EditStream
+  enforces ≥1.0s. Below 200ms, Telegram clients struggle to animate smoothly.
+- **Keepalive**: If no tokens arrive for `keepalive_timeout` seconds (default
+  25s, configurable), auto-resend current state to prevent draft expiry. The
+  default is conservative against a ~30s observed expiry window; callers can
+  lower this if Telegram tightens the window.
+- **Burst absorption**: Multiple tokens between timer fires are batched into one
+  re-parse + one `emit()` call.
+- **Backpressure**: The buffer grows monotonically regardless of send success.
+  For typical LLM outputs (< 100KB), memory is not a concern. The splitting
+  pipeline handles overflow at finalization. If buffer exceeds 512KB (an
+  implausible but defensive limit), the stream logs a warning — this suggests
+  the caller forgot to finalize.
+
+### State machine (StreamCore)
+
+```text
+┌────────┐   feed()/consume()   ┌────────┐   finish()/cancel()   ┌────────┐
+│  IDLE  │─────────────────────▶│ ACTIVE │───────────────────────▶│  DONE  │
+└────────┘                      └────────┘                        └────────┘
+```
+
+- **IDLE**: No tokens received. No timer. No API calls.
+- **ACTIVE**: Timer running, periodic `emit()`. The strategy facade may inject
+  "thinking" behavior as a hook on the first emit — the core does not distinguish.
+- **DONE**: Terminal. Reached via `finish()` (calls `finalize`) or `cancel()`
+  (calls `on_cancel`). Timer stopped. Subsequent `feed()` raises `RuntimeError`.
+
+### Error handling (StreamCore)
+
+| Failure | Behavior |
+|---|---|
+| `emit()` raises | Log warning, skip this update, stay dirty for next interval |
+| `emit()` raises 3× consecutive | Transition to degraded mode: stop emitting, accumulate silently, still call `finalize` on finish |
+| `finalize()` raises | Propagate to caller (critical: final content would be lost) |
+| `CancelledError` in wrapping Task | Route to `cancel()` — no `finalize`, calls `on_cancel` if set |
+
+Strategy-layer policies (DraftStream):
+
+| Failure | Behavior |
+|---|---|
+| Draft expires (no update within expiry window) | Should not happen if keepalive works; if detected, restart draft with fresh ID |
+| Token stream stalls > `keepalive_timeout` | Auto-resend current buffer state (keepalive fires as a normal emit tick) |
+
+### Concurrency model (StreamCore)
+
+`StreamCore` operates within a **single asyncio event loop**. It does not
+support multi-threaded access. All state transitions are sequential under
+asyncio's cooperative scheduling.
+
+**Guards against race conditions:**
+
+1. **`_sending` flag**: A boolean guard that prevents overlapping `emit` and
+   `finalize` calls. When the timer fires while a previous send is still
+   awaiting, the new tick is a no-op (buffer stays dirty for the next tick).
+
+2. **`finish()` cancels the timer first**: On entry, `finish()` cancels any
+   pending timer task, awaits the `_sending` flag to clear (if a send is
+   in-flight), then calls `finalize(render(buffer))`.
+
+3. **Post-DONE no-ops**: After transitioning to DONE, any subsequent timer
+   fires (from scheduling race) check state and exit immediately.
+
+4. **`CancelledError` path**: If the wrapping asyncio Task is cancelled,
+   `__aexit__` receives `CancelledError` and routes to `cancel()` instead of
+   `finish()`.
+
+```text
+Timer fires:
+    if state == DONE: return (no-op)
+    if _sending: return (skip this tick, stay dirty)
+    _sending = True
+    try: await emit(render(buffer))
+    finally: _sending = False
+
+finish():
+    cancel timer
+    await until _sending == False
+    state = DONE
+    await finalize(render(buffer))
+
+cancel():
+    cancel timer
+    state = DONE
+    if on_cancel: await on_cancel()
+```
+
+### Cancellation
+
+Cancellation is a Phase 1 requirement. LLM users frequently stop generation
+mid-stream; without explicit cancellation, the context manager would call
+`finalize` with partial content the user explicitly abandoned.
+
+```python
+# Explicit cancellation
+await stream.cancel()
+
+# Implicit via CancelledError (asyncio task cancellation)
+# __aexit__ detects CancelledError → calls cancel() internally
+```
+
+At the `StreamCore` level, `cancel()`:
+- Cancels the timer.
+- Transitions state to DONE.
+- Calls `on_cancel()` if provided (strategy-injected cleanup).
+- Does NOT call `finalize`.
+
+At the `DraftStream` level, `on_cancel` is wired to send an empty draft
+(clearing the "Thinking…" indicator) when `cancel_clears_draft=True`.
+
+### Thinking delay (DraftStream policy)
+
+When `thinking_delay > 0`, `DraftStream` hooks into the first `emit` call:
+
+1. On first `feed()`, immediately emit an empty payload (Telegram client renders
+   its built-in localized "Thinking…" indicator — not a library-hardcoded string).
+2. Start a `thinking_delay` timer. Suppress subsequent `emit` calls until the
+   timer expires or buffer exceeds a threshold (whichever comes first).
+3. After the delay, normal throttled emission resumes.
+
+This is entirely a strategy-layer concern. `StreamCore` knows nothing about it —
+it just calls `emit(render(buffer))` on schedule. The `DraftStream` wrapper
+intercepts early emits.
+
+### Splitting during streaming
+
+Both modes face limits on draft content size. The strategy differs by mode.
+
+**Entity mode** (4096 character limit):
+- When buffer exceeds 4096 characters after rendering, the draft displays only
+  the **trailing 4096 characters** (sliding window). The user sees the most
+  recent output scrolling by.
+- On finalization, the full buffer is processed through `telegramify()` which
+  splits into `list[Text | File | Photo]` as normal.
+
+**Rich mode** (32768 bytes / 500 blocks):
+- When buffer exceeds Rich Message limits, the draft displays the **trailing
+  window** of blocks that fit within limits (sliding window over rendered
+  blocks, not a post-split chunk boundary).
+- This avoids the UX cliff where content would suddenly jump from "full 31KB
+  document" to "1KB tail of chunk 2" at a split boundary.
+- On finalization, `telegramify_rich()` splits and sends all chunks
+  sequentially.
+
+**Known trade-off**: in both modes, once the buffer exceeds draft limits, the
+user loses sight of earlier content until finalization delivers all chunks. This
+is acceptable because (a) the user sees content scrolling naturally, and (b) the
+alternative — sending finalized chunks mid-stream — causes confusing message
+count jumps.
+
+### Pipeline interaction during streaming
+
+Draft updates use **lightweight rendering only**:
+- Entity mode: `convert()` → text + entities. No Mermaid rendering, no code
+  extraction to File, no image download.
+- Rich mode: `richify()` → `InputRichMessage`. No media attachment resolution.
+
+On finalization, the **full pipeline** runs:
+- Entity mode: `telegramify()` → may produce File (long code blocks), Photo
+  (Mermaid diagrams), and multiple Text items.
+- Rich mode: `telegramify_rich()` → splitting, all rich features active.
+
+This means users see Mermaid source code (as a code block) during streaming,
+which transforms into a rendered image on finalization. This is an acceptable
+and expected UX trade-off — rendering Mermaid takes seconds and cannot happen at
+streaming speed.
+
+## Data-Centered Decisions
+
+1. **Fact vs state**: The accumulated token buffer is mutable state (an
+   append-only log of tokens). Each `emit()` output is a projection of the
+   current buffer state — ephemeral, overwritten by the next emit. The
+   `finalize()` output is the fact (persisted by Telegram).
+
+2. **Value semantics**: `interval` is in seconds (float). `draft_id` is a
+   nonzero int64 matching Telegram's type. `thinking_delay` is seconds before
+   first substantive emit.
+
+3. **Parse boundary**: Same as ADR-001 — `pyromark.events_with_range()`. The
+   streaming layer does not introduce a new parse boundary; it repeatedly
+   invokes the existing one via the injected `render` callable.
+
+4. **Field classification**:
+   - `StreamCore` internal state (buffer, dirty flag, timer, _sending) — internal
+   - `render` output (payload passed to emit/finalize) — public key-fact
+   - Error counts, last-emit timestamp — audit detail
+
+5. **Authority**: Telegram Bot API docs for draft semantics. Local benchmarks
+   for parse cost. Library's own `convert()` / `richify()` for rendering.
+   `StreamCore` has no authority dependency — it is Telegram-agnostic.
+
+6. **Absence semantics**: `thinking_delay=None` means skip the thinking phase
+   (immediately start emitting rendered content). `on_cancel=None` means cancel
+   is silent (no cleanup call).
+
+7. **Projection strategy**: `StreamCore` is generic over payload type `T`.
+   Payload dataclasses are declared once per strategy (matching Telegram API
+   parameter names). No intermediate transform types.
+
+## Flags
+
+### Flag 1: Re-parse produces valid output on incomplete Markdown
+
+**Expectation.** pyromark + the walker produce valid (if incomplete) output for
+any prefix of a well-formed Markdown document. Unclosed fences, partial emphasis,
+and dangling links all render as visible text rather than crashing or producing
+broken HTML. Token boundaries at emoji / CJK / surrogate-pair positions do not
+affect correctness (Python `str` is UCS-4; no half-surrogate can exist in the
+buffer).
+
+**Verification.** Unit test: take a 5KB fixture containing CJK, emoji, and RTL
+text; split it at every 100-byte boundary; feed each prefix through `richify()`
+and `convert()`. Assert no exceptions and valid output structure.
+
+### Flag 2: Throttle respects minimum interval
+
+**Expectation.** Regardless of `feed()` call frequency, the `send_draft`
+callback is invoked at most once per `interval` seconds.
+
+**Verification.** Unit test with mocked time: feed 1000 tokens in 0ms, assert
+`send_draft` called exactly once within the first interval.
+
+### Flag 3: Draft keepalive prevents expiry
+
+**Expectation.** If no new tokens arrive for 25+ seconds, the stream
+auto-resends the current state to prevent draft expiry.
+
+**Verification.** Unit test with mocked time: feed one token, advance clock 26s
+without new tokens, assert `send_draft` called at t=25s.
+
+### Flag 4: Finalization sends complete message
+
+**Expectation.** On `finish()` or `__aexit__`, the full buffer is re-parsed
+one final time and `send_final` is called exactly once.
+
+**Verification.** Unit test: feed tokens, call finish, assert `send_final`
+called with the complete rendered output.
+
+### Flag 5: EditStream enforces ≥1s interval
+
+**Expectation.** `EditStream` refuses `interval < 1.0` at construction time and
+emits edits at exactly the configured interval (never faster than Telegram's
+1 edit/second limit).
+
+**Verification.** Unit test: construct `EditStream(interval=0.5)`, assert
+`ValueError`. Construct with `interval=1.5`, feed tokens rapidly, assert
+`edit_message` called at ≥1.5s intervals.
+
+### Flag 6: Degraded mode after repeated failures
+
+**Expectation.** After 3 consecutive `send_draft` failures, the stream stops
+calling `send_draft` and only sends the final message.
+
+**Verification.** Unit test: mock `send_draft` to always raise, feed tokens,
+call finish. Assert `send_draft` called ≤3 times, `send_final` called once
+with complete content.
+
+### Flag 7: Cancellation does not send final message
+
+**Expectation.** When `cancel()` is called (or `CancelledError` propagates),
+no `send_final` is invoked. If `cancel_clears_draft=True`, an empty draft is
+sent to clear the indicator.
+
+**Verification.** Unit test: feed tokens, call `cancel()`, assert `send_final`
+never called. Assert empty-draft send occurred when `cancel_clears_draft=True`.
+
+### Flag 8: Concurrent send guard prevents overlapping emit calls
+
+**Expectation.** If `emit()` await takes longer than `interval`, the next
+timer tick is skipped (not queued). At no point are two `emit` calls in flight
+simultaneously.
+
+**Verification.** Unit test: mock `emit` to sleep 2× interval, feed tokens
+continuously, assert no overlapping calls (use a counter that raises if > 1).
+
+## Considered Alternatives
+
+| Option | Why rejected |
+|---|---|
+| Monolithic DraftStream with `mode` + `fallback` params | Mixes mechanism (throttle/buffer/concurrency) with strategy (draft vs edit, rich vs entity). Adding a new transport requires modifying core. Tested via first-principles analysis — see §Prior Art. |
+| Incremental Markdown parsing (delta only) | pyromark has no incremental API; a backtick retroactively changes parse tree. The 0.18ms full-reparse cost makes this unnecessary complexity. |
+| Library embeds HTTP client | Violates the library boundary (no bot tokens, no network I/O). Different bot frameworks (aiogram, python-telegram-bot, telethon) use different async runtimes. |
+| Synchronous streaming API | Draft updates are inherently async (timer-based, network I/O in callbacks). A sync API would require threads and complicate the caller's event loop. |
+| Token-level diffing (send only changed portions) | Telegram draft API replaces the entire message content. There is no patch/delta endpoint. |
+| Split mid-stream (send multiple drafts simultaneously) | Confusing UX; user sees message count jumping during generation. Defer splitting to finalization. |
+| Show post-split last chunk during streaming | Creates a UX cliff (31KB → 1KB jump at boundary). Sliding window is smoother. |
+
+### Prior art
+
+Production LLM Telegram bots (OpenClaw, Hermes Agent, grammY streaming plugin)
+converged on the same core pattern: buffer + throttle + overwrite-emit. Key
+lessons incorporated:
+
+- **OpenClaw**: Migrated from `sendMessage` + `editMessageText` to
+  `sendMessageDraft` (Bot API 9.5+). Documented the "inFlight mutex" pattern
+  for preventing overlapping edits — directly maps to our `_sending` guard.
+- **Hermes Agent**: UTF-16-aware overflow splitting during edit streaming.
+  Confirms the need for sliding-window truncation rather than hard errors.
+- **grammY streaming plugin**: Identified that Markdown formatting during
+  streaming is the hardest problem (partial entities break). Our approach —
+  full re-parse via pyromark on each tick — sidesteps this entirely.
+
+@see OpenClaw PR #32041 — sendMessageDraft migration decision
+@see grammY streaming docs — Markdown entity streaming pitfalls
+
+## Implementation Plan
+
+### Phase 1: Core mechanism + Draft facade (this ADR)
+
+1. `src/telegramify_markdown/stream/core.py` — `StreamCore[T]` generic class
+   (buffer, throttle, concurrency model, state machine, cancel/finish).
+2. `src/telegramify_markdown/stream/draft.py` — `DraftStream` facade (render
+   selection, thinking delay, sliding window, draft_id, cancel_clears_draft).
+3. `src/telegramify_markdown/stream/edit.py` — `EditStream` facade (send +
+   edit callbacks, interval ≥1s enforcement).
+4. `src/telegramify_markdown/stream/__init__.py` — public exports.
+5. Payload dataclasses in `src/telegramify_markdown/content.py`.
+6. Unit tests for all 8 flags (pytest-asyncio + manual event loop advancement).
+   Core tests use trivial `render`/`emit` mocks — no Telegram payload knowledge.
+7. README documentation.
+
+### Phase 2: Convenience wrappers (future, after community feedback)
+
+- Pre-built callback adapters for popular frameworks (aiogram, python-telegram-bot)
+- CLI playground for manual testing with a real bot
+
+### Phase 3: Advanced features (future)
+
+- Cursor/typing indicator position hints
+- Multi-message streaming (streaming into message N while messages 1..N-1 are
+  already finalized)
+- Rich Markdown mode streaming (pass through partial Markdown directly)
+
+## Open Questions
+
+| # | Question | Status |
+|---|---|---|
+| 1 | Cancellation support | **Resolved** — included in Phase 1 with `cancel()` method and `CancelledError` handling. See §Cancellation. |
+| 2 | Should the library provide a rate-limit detector (429 backoff)? | Open — likely out of scope since the library does not own HTTP. Caller can implement backoff in their `send_draft` callback. |
+| 3 | `sendRichMessageDraft` parameter shape | **Resolved** — accepts `chat_id` + `draft_id` + `rich_message` (InputRichMessage object). Same callback shape as `send_draft` for rich mode. |
+| 4 | Exact draft expiry duration | Open — 30s is community-observed, not officially documented. The `keepalive_timeout` parameter lets callers adapt without a library release. |
+
+## References
+
+- @see [ADR-001](./001-rich-message-pipeline-composition.md) — Rich Message splitting
+- @see [Rich Message PRD](../prd/rich-message.md)
+- @see https://core.telegram.org/bots/api#sendmessagedraft
+- @see https://core.telegram.org/bots/api#sendrichmessagedraft
+- @see https://core.telegram.org/bots/api-changelog (Bot API 9.3, 9.5, 10.0, 10.1)

--- a/docs/adr/ACTIVE.md
+++ b/docs/adr/ACTIVE.md
@@ -17,6 +17,7 @@
 
 | ADR | Author | Date | Summary |
 |-----|--------|------|---------|
+| [ADR-002](./002-streaming-draft-support.md) | Lilith | 2026-06-13 | Two-layer async streaming architecture — a protocol-agnostic StreamCore (buffer + throttle + concurrency) composed with strategy facades (DraftStream, EditStream) that inject rendering and Telegram transport. |
 | [ADR-001](./001-rich-message-pipeline-composition.md) | Codex | 2026-06-12 | Split Rich Message output at pyromark source block boundaries, not at rendered HTML byte offsets. Rich Message delivery is a parallel pipeline to the Entity pipeline, sharing the same parse boundary. |
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -61,6 +61,54 @@ for chunk_text, chunk_entities in split_entities(text, entities, max_utf16_len=4
     bot.send_message(chat_id, chunk_text, entities=[e.to_dict() for e in chunk_entities])
 ```
 
+## Usage: DraftStream — streaming LLM output (Bot API 9.3+)
+
+For token-by-token LLM output in private chats. Sends intermediate drafts via
+sendMessageDraft / sendRichMessageDraft, then finalizes with the complete message.
+
+```python
+from telegramify_markdown.stream import DraftStream
+
+async def send_draft(payload):
+    # payload is RichDraftPayload with .rich_message.to_dict() and .draft_id
+    requests.post(f"https://api.telegram.org/bot{token}/sendRichMessageDraft",
+        json={"chat_id": chat_id, "draft_id": payload.draft_id,
+              "rich_message": payload.rich_message.to_dict()})
+
+async def send_final(payload):
+    # payload is RichFinalPayload with .rich_message.to_dict()
+    requests.post(f"https://api.telegram.org/bot{token}/sendRichMessage",
+        json={"chat_id": chat_id, "rich_message": payload.rich_message.to_dict()})
+
+async with DraftStream(
+    send_draft=send_draft,
+    send_final=send_final,
+    mode="rich",            # "rich" | "entity"
+    interval=0.3,           # seconds between draft updates
+    thinking_delay=0.5,     # show thinking indicator before first content
+    keepalive_timeout=25.0, # prevent draft expiry (~30s)
+) as stream:
+    async for tok in llm_response:
+        stream.feed(tok)
+```
+
+## Usage: EditStream — streaming in group chats
+
+For group/channel chats where draft API is unavailable. Sends message then edits it.
+
+```python
+from telegramify_markdown.stream import EditStream
+
+async with EditStream(
+    send_message=my_send_fn,   # async (payload) -> message_id
+    edit_message=my_edit_fn,   # async (message_id, payload) -> None
+    mode="rich",
+    interval=1.0,              # >= 1.0s enforced (Telegram edit rate limit)
+) as stream:
+    async for tok in llm_response:
+        stream.feed(tok)
+```
+
 ## Configuration
 
 ```python
@@ -246,3 +294,5 @@ telegramify() → list[Text | File | Photo]      # async pipeline
 - Entity offsets are in UTF-16 code units, not Python string indices. Use `utf16_len()` to measure.
 - The library is bot-framework agnostic. `MessageEntity.to_dict()` works with pyTelegramBotAPI, python-telegram-bot, aiogram, and any library that accepts entity dicts.
 - For messages that might exceed 4096 characters, use `telegramify()` (auto-splits) or `split_entities()` (manual split).
+- For streaming LLM output token-by-token, use `DraftStream` (private chats) or `EditStream` (groups). The library handles throttling, keepalive, and concurrency.
+- `DraftStream`/`EditStream` are async context managers. The caller provides send/edit callbacks — the library does NOT make HTTP calls itself.

--- a/llms.txt
+++ b/llms.txt
@@ -25,6 +25,7 @@ Key design decisions:
 - [MessageEntity — entity.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/entity.py): MessageEntity dataclass, `utf16_len()`, `split_entities()`
 - [MarkdownV2 reverse converter — mdv2.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/mdv2.py): `entities_to_markdownv2()` for APIs that only support parse_mode
 - [Async pipeline — pipeline.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/pipeline.py): Message splitting, code block extraction, Mermaid rendering
+- [Streaming — stream/](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/stream/__init__.py): `DraftStream` (private chat drafts), `EditStream` (group edit fallback), `StreamCore` (generic throttled buffer)
 - [Output types — content.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/content.py): Text, File, Photo, ContentType, ContentTrace
 - [Configuration — config.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/config.py): Symbol customization, RenderConfig singleton
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "mermaid", "tests"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:e9ff4997a8a3b8a5c5e16e1272ca30bb38d49de074f6dd0869e865c46b74d91e"
+content_hash = "sha256:89fa490d55e52f5cfc1e15ff263861f977481b73d948567152ab653361e84a12"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -182,6 +182,18 @@ files = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+requires_python = "<3.11,>=3.8"
+summary = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
+groups = ["tests"]
+marker = "python_version < \"3.11\""
+files = [
+    {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
+    {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 requires_python = ">=3.7"
@@ -281,6 +293,33 @@ files = [
     {file = "charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2"},
     {file = "charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f"},
     {file = "charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"},
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+summary = "Cross-platform colored terminal text."
+groups = ["tests"]
+marker = "sys_platform == \"win32\""
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+requires_python = ">=3.7"
+summary = "Backport of PEP 654 (exception groups)"
+groups = ["tests"]
+marker = "python_version < \"3.11\""
+dependencies = [
+    "typing-extensions>=4.6.0; python_version < \"3.13\"",
+]
+files = [
+    {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
+    {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
 ]
 
 [[package]]
@@ -415,6 +454,17 @@ groups = ["mermaid", "tests"]
 files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+requires_python = ">=3.10"
+summary = "brain-dead simple config-ini parsing"
+groups = ["tests"]
+files = [
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
 
 [[package]]
@@ -558,6 +608,17 @@ files = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+requires_python = ">=3.8"
+summary = "Core utilities for Python packages"
+groups = ["tests"]
+files = [
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
+]
+
+[[package]]
 name = "pillow"
 version = "12.1.0"
 requires_python = ">=3.10"
@@ -655,6 +716,17 @@ files = [
     {file = "pillow-12.1.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5da841d81b1a05ef940a8567da92decaa15bc4d7dedb540a8c219ad83d91808a"},
     {file = "pillow-12.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:75af0b4c229ac519b155028fa1be632d812a519abba9b46b20e50c6caa184f19"},
     {file = "pillow-12.1.0.tar.gz", hash = "sha256:5c5ae0a06e9ea030ab786b0251b32c7e4ce10e58d983c0d5c56029455180b5b9"},
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+requires_python = ">=3.9"
+summary = "plugin and hook calling mechanisms for python"
+groups = ["tests"]
+files = [
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [[package]]
@@ -771,6 +843,17 @@ files = [
     {file = "propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9"},
     {file = "propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237"},
     {file = "propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d"},
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+requires_python = ">=3.9"
+summary = "Pygments is a syntax highlighting package written in Python."
+groups = ["tests"]
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [[package]]
@@ -989,6 +1072,42 @@ files = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.3"
+requires_python = ">=3.10"
+summary = "pytest: simple powerful testing with Python"
+groups = ["tests"]
+dependencies = [
+    "colorama>=0.4; sys_platform == \"win32\"",
+    "exceptiongroup>=1; python_version < \"3.11\"",
+    "iniconfig>=1.0.1",
+    "packaging>=22",
+    "pluggy<2,>=1.5",
+    "pygments>=2.7.2",
+    "tomli>=1; python_version < \"3.11\"",
+]
+files = [
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+requires_python = ">=3.10"
+summary = "Pytest support for asyncio"
+groups = ["tests"]
+dependencies = [
+    "backports-asyncio-runner<2,>=1.1; python_version < \"3.11\"",
+    "pytest<10,>=8.4",
+    "typing-extensions>=4.12; python_version < \"3.13\"",
+]
+files = [
+    {file = "pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1"},
+    {file = "pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"},
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 requires_python = ">=3.9"
@@ -1083,11 +1202,68 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.4.1"
+requires_python = ">=3.8"
+summary = "A lil' TOML parser"
+groups = ["tests"]
+marker = "python_version < \"3.11\""
+files = [
+    {file = "tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30"},
+    {file = "tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a"},
+    {file = "tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076"},
+    {file = "tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9"},
+    {file = "tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c"},
+    {file = "tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc"},
+    {file = "tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049"},
+    {file = "tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e"},
+    {file = "tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece"},
+    {file = "tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a"},
+    {file = "tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085"},
+    {file = "tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9"},
+    {file = "tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5"},
+    {file = "tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585"},
+    {file = "tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1"},
+    {file = "tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917"},
+    {file = "tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9"},
+    {file = "tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257"},
+    {file = "tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54"},
+    {file = "tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a"},
+    {file = "tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897"},
+    {file = "tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f"},
+    {file = "tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d"},
+    {file = "tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5"},
+    {file = "tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd"},
+    {file = "tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36"},
+    {file = "tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd"},
+    {file = "tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf"},
+    {file = "tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac"},
+    {file = "tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662"},
+    {file = "tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853"},
+    {file = "tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15"},
+    {file = "tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba"},
+    {file = "tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6"},
+    {file = "tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7"},
+    {file = "tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232"},
+    {file = "tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4"},
+    {file = "tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c"},
+    {file = "tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d"},
+    {file = "tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41"},
+    {file = "tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c"},
+    {file = "tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f"},
+    {file = "tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8"},
+    {file = "tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26"},
+    {file = "tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396"},
+    {file = "tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe"},
+    {file = "tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 requires_python = ">=3.9"
 summary = "Backported and Experimental Type Hints for Python 3.9+"
-groups = ["default", "mermaid"]
+groups = ["default", "mermaid", "tests"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},

--- a/playground/stream_draft_case.py
+++ b/playground/stream_draft_case.py
@@ -1,0 +1,186 @@
+"""Live streaming draft showcase — sends token-by-token via sendRichMessageDraft.
+
+Demonstrates DraftStream with the real Telegram Bot API.
+The bot will show a "thinking" indicator, then progressively render markdown
+as rich message draft updates, and finally send the complete message.
+
+Run: pdm run python playground/stream_draft_case.py
+
+Requires:
+- TELEGRAM_BOT_TOKEN
+- TELEGRAM_CHAT_ID (must be a private chat with the bot)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.error
+import urllib.request
+
+from dotenv import load_dotenv
+
+from telegramify_markdown.stream.draft import (
+    DraftStream,
+    RichDraftPayload,
+    RichFinalPayload,
+)
+
+
+def _post_bot_api_json(token: str, method_name: str, payload: dict) -> dict:
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"https://api.telegram.org/bot{token}/{method_name}",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            result = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"Telegram {method_name} rejected: HTTP {exc.code}: {error_body[:500]}"
+        ) from exc
+
+    if not result.get("ok"):
+        raise RuntimeError(f"Telegram {method_name} ok=false: {result!r}")
+    return result["result"]
+
+
+# ---------------------------------------------------------------------------
+# 模拟 LLM token 流
+# ---------------------------------------------------------------------------
+
+SAMPLE_MARKDOWN = """\
+# Streaming Draft Demo
+
+This message is being **streamed** token-by-token via `sendRichMessageDraft`.
+
+## Features
+
+- Thinking indicator on first emit
+- Throttled updates (~300ms interval)
+- Keepalive prevents draft expiry
+- Final message via `sendRichMessage`
+
+## Code Example
+
+```python
+async with DraftStream(send_draft, send_final, mode="rich") as stream:
+    async for token in llm_response:
+        stream.feed(token)
+```
+
+## Table
+
+| Layer | Responsibility |
+| --- | --- |
+| StreamCore | Buffer + throttle + concurrency |
+| DraftStream | Telegram draft API + thinking delay |
+| EditStream | Group chat edit fallback |
+
+> 流式输出完成 ✅
+"""
+
+
+async def simulate_llm_tokens(text: str, delay: float = 0.03):
+    """模拟 LLM 逐 token 输出。"""
+    # 按词+标点切分，模拟真实 token
+    tokens = []
+    current = ""
+    for ch in text:
+        current += ch
+        if ch in (" ", "\n", ".", ",", "!", "?", "`", "*", "|", "-"):
+            tokens.append(current)
+            current = ""
+    if current:
+        tokens.append(current)
+
+    for token in tokens:
+        yield token
+        await asyncio.sleep(delay)
+
+
+# ---------------------------------------------------------------------------
+# Telegram callback 实现
+# ---------------------------------------------------------------------------
+
+
+class TelegramDraftCallbacks:
+    """将 DraftStream 的 emit/finalize 映射到 Telegram Bot API 调用。"""
+
+    def __init__(self, token: str, chat_id: str):
+        self.token = token
+        self.chat_id = chat_id
+        self.draft_count = 0
+        self.final_message_id: int | None = None
+
+    async def send_draft(self, payload: RichDraftPayload) -> None:
+        """调用 sendRichMessageDraft。"""
+        self.draft_count += 1
+        api_payload = {
+            "chat_id": self.chat_id,
+            "draft_id": payload.draft_id,
+            "rich_message": payload.rich_message.to_dict(),
+        }
+        try:
+            _post_bot_api_json(self.token, "sendRichMessageDraft", api_payload)
+            print(f"  [draft #{self.draft_count}] sent ({len(payload.rich_message.html or '')} bytes HTML)")
+        except Exception as e:
+            print(f"  [draft #{self.draft_count}] FAILED: {e}")
+            raise
+
+    async def send_final(self, payload: RichFinalPayload) -> None:
+        """调用 sendRichMessage 发送最终消息。"""
+        api_payload = {
+            "chat_id": self.chat_id,
+            "rich_message": payload.rich_message.to_dict(),
+            "disable_notification": True,
+        }
+        result = _post_bot_api_json(self.token, "sendRichMessage", api_payload)
+        self.final_message_id = result.get("message_id")
+        print(f"  [final] message_id={self.final_message_id}")
+
+
+async def main() -> int:
+    load_dotenv()
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        print("ERROR: TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required")
+        print("       (chat must be a private chat with the bot for draft API)")
+        return 1
+
+    print("=== Streaming Draft Live Test ===")
+    print(f"Chat ID: {chat_id}")
+    print()
+
+    callbacks = TelegramDraftCallbacks(token, chat_id)
+
+    print("[1] Starting DraftStream (mode=rich, interval=0.3s, thinking_delay=0.5s)")
+    async with DraftStream(
+        send_draft=callbacks.send_draft,
+        send_final=callbacks.send_final,
+        mode="rich",
+        interval=0.3,
+        thinking_delay=0.5,
+        keepalive_timeout=25.0,
+        cancel_clears_draft=True,
+    ) as stream:
+        print("[2] Feeding tokens...")
+        async for token in simulate_llm_tokens(SAMPLE_MARKDOWN, delay=0.03):
+            stream.feed(token)
+
+    print()
+    print("=== Results ===")
+    print(f"  Drafts sent: {callbacks.draft_count}")
+    print(f"  Final message ID: {callbacks.final_message_id}")
+    print(f"  Status: {'SUCCESS' if callbacks.final_message_id else 'FAILED'}")
+
+    return 0 if callbacks.final_message_id else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ tests = [
     "pyTelegramBotAPI>=4.22.0",
     "python-dotenv>=1.0.1",
     "PyYAML>=6.0.3",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
 ]
 
 [project.urls]
@@ -39,3 +41,8 @@ distribution = true
 test = "python -m unittest discover -s ./tests -p test_*.py"
 test-rich = "python -m unittest tests.test_rich"
 test-live-rich = { cmd = "python -m unittest tests.test_server.TelegramRichMessageLiveTest", env = { TELEGRAM_LIVE_REQUIRED = "1" } }
+test-live-stream = { cmd = "python -m unittest tests.test_server.TelegramStreamDraftLiveTest", env = { TELEGRAM_LIVE_REQUIRED = "1" } }
+test-stream = "pytest tests/test_stream.py -v"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/src/telegramify_markdown/stream/__init__.py
+++ b/src/telegramify_markdown/stream/__init__.py
@@ -1,0 +1,10 @@
+"""Streaming draft support for LLM token-by-token output.
+
+@see docs/adr/002-streaming-draft-support.md
+"""
+
+from telegramify_markdown.stream.core import StreamCore
+from telegramify_markdown.stream.draft import DraftStream
+from telegramify_markdown.stream.edit import EditStream
+
+__all__ = ["StreamCore", "DraftStream", "EditStream"]

--- a/src/telegramify_markdown/stream/core.py
+++ b/src/telegramify_markdown/stream/core.py
@@ -1,0 +1,239 @@
+"""Protocol-agnostic throttled streaming buffer.
+
+StreamCore is the mechanism layer: it accumulates tokens into a buffer, renders
+on a throttled schedule via an injected callable, emits snapshots via an injected
+callback, and finalizes via an injected callback. It knows nothing about Telegram,
+Markdown, or Rich HTML.
+
+@see docs/adr/002-streaming-draft-support.md §StreamCore
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+from typing import AsyncIterator, Awaitable, Callable, Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+_BUFFER_WARNING_BYTES = 512 * 1024  # 512KB
+
+
+class _State(enum.Enum):
+    IDLE = "idle"
+    ACTIVE = "active"
+    DONE = "done"
+
+
+class StreamCore(Generic[T]):
+    """Protocol-agnostic throttled streaming buffer.
+
+    Generic over payload type T. The core only knows about:
+    - buffer (str, append-only)
+    - render: Callable[[str], T]
+    - emit: Callable[[T], Awaitable[None]]
+    - finalize: Callable[[T], Awaitable[None]]
+    """
+
+    def __init__(
+        self,
+        render: Callable[[str], T],
+        emit: Callable[[T], Awaitable[None]],
+        finalize: Callable[[T], Awaitable[None]],
+        interval: float = 0.3,
+        keepalive_timeout: float = 25.0,
+        on_cancel: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
+        if interval <= 0:
+            raise ValueError(f"interval must be positive, got {interval}")
+
+        self._render = render
+        self._emit = emit
+        self._finalize = finalize
+        self._interval = interval
+        self._keepalive_timeout = keepalive_timeout
+        self._on_cancel = on_cancel
+
+        self._buffer = ""
+        self._dirty = False
+        self._sending = False
+        self._state = _State.IDLE
+        self._consecutive_failures = 0
+        self._degraded = False
+
+        self._timer_handle: asyncio.TimerHandle | None = None
+        self._keepalive_handle: asyncio.TimerHandle | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._buffer_warned = False
+        self._keepalive_expired = False
+
+    @property
+    def buffer(self) -> str:
+        """当前累积的 buffer 内容（只读）。"""
+        return self._buffer
+
+    @property
+    def state(self) -> str:
+        """当前状态：idle / active / done。"""
+        return self._state.value
+
+    async def __aenter__(self) -> "StreamCore[T]":
+        self._loop = asyncio.get_running_loop()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        if self._state == _State.DONE:
+            return False
+        if exc_type is asyncio.CancelledError:
+            await self.cancel()
+            return True  # suppress CancelledError
+        if exc_type is None:
+            await self.finish()
+        else:
+            # 异常退出：尝试 cancel 而非 finalize
+            await self.cancel()
+        return False
+
+    def feed(self, token: str) -> None:
+        """追加 token 到 buffer。"""
+        if self._state == _State.DONE:
+            raise RuntimeError("Cannot feed after stream is done")
+
+        self._buffer += token
+        self._dirty = True
+
+        # 检查 buffer 大小告警
+        if not self._buffer_warned and len(self._buffer.encode("utf-8")) > _BUFFER_WARNING_BYTES:
+            logger.warning(
+                "Stream buffer exceeds 512KB (%d bytes). "
+                "Did you forget to call finish()?",
+                len(self._buffer.encode("utf-8")),
+            )
+            self._buffer_warned = True
+
+        if self._state == _State.IDLE:
+            self._state = _State.ACTIVE
+            self._schedule_tick()
+
+    async def consume(self, tokens: AsyncIterator[str]) -> None:
+        """从 async iterator 消费 tokens，结束后自动 finish。
+
+        如果 iterator 抛出 CancelledError，调用 cancel()。
+        """
+        try:
+            async for token in tokens:
+                self.feed(token)
+        except asyncio.CancelledError:
+            await self.cancel()
+            return
+        await self.finish()
+
+    async def finish(self) -> None:
+        """终止流并发送最终消息。"""
+        if self._state == _State.DONE:
+            return
+
+        self._cancel_timers()
+
+        # 等待飞行中的 emit 完成
+        while self._sending:
+            await asyncio.sleep(0.01)
+
+        self._state = _State.DONE
+
+        if self._buffer:
+            payload = self._render(self._buffer)
+            await self._finalize(payload)
+
+    async def cancel(self) -> None:
+        """取消流，不发送最终消息。"""
+        if self._state == _State.DONE:
+            return
+
+        self._cancel_timers()
+        self._state = _State.DONE
+
+        if self._on_cancel:
+            await self._on_cancel()
+
+    def _schedule_tick(self) -> None:
+        """安排下一次 tick。"""
+        if self._state == _State.DONE or self._loop is None:
+            return
+        self._timer_handle = self._loop.call_later(
+            self._interval, self._tick_sync
+        )
+
+    def _tick_sync(self) -> None:
+        """Timer callback（同步入口），创建 async task。"""
+        if self._state == _State.DONE:
+            return
+        if self._loop is not None:
+            self._loop.create_task(self._tick())
+
+    async def _tick(self) -> None:
+        """执行一次节流 emit。"""
+        if self._state == _State.DONE:
+            return
+        if self._sending:
+            # 上一次还在发送中，跳过本次 tick，保持 dirty
+            self._schedule_tick()
+            return
+        if not self._dirty and not self._is_keepalive_due():
+            self._schedule_tick()
+            return
+
+        if self._degraded:
+            # 降级模式：不再 emit，但继续 schedule 以维持 keepalive 计时
+            self._dirty = False
+            self._schedule_tick()
+            return
+
+        self._sending = True
+        try:
+            payload = self._render(self._buffer)
+            await self._emit(payload)
+            self._dirty = False
+            self._consecutive_failures = 0
+            self._reset_keepalive()
+        except Exception as e:
+            self._consecutive_failures += 1
+            logger.warning("emit failed (%d/3): %s", self._consecutive_failures, e)
+            if self._consecutive_failures >= 3:
+                logger.warning("Entering degraded mode: emit disabled")
+                self._degraded = True
+        finally:
+            self._sending = False
+
+        self._schedule_tick()
+
+    def _is_keepalive_due(self) -> bool:
+        """keepalive 是否应当触发（通过 keepalive handle 是否已过期来判断）。"""
+        # keepalive 通过独立 handle 标记
+        return self._keepalive_expired
+
+    def _reset_keepalive(self) -> None:
+        """重置 keepalive 计时器。"""
+        if self._keepalive_handle is not None:
+            self._keepalive_handle.cancel()
+        self._keepalive_expired = False
+        if self._loop is not None and self._state != _State.DONE:
+            self._keepalive_handle = self._loop.call_later(
+                self._keepalive_timeout, self._mark_keepalive_expired
+            )
+
+    def _mark_keepalive_expired(self) -> None:
+        """标记 keepalive 已过期，下次 tick 将强制发送。"""
+        self._keepalive_expired = True
+
+    def _cancel_timers(self) -> None:
+        """取消所有 pending timer。"""
+        if self._timer_handle is not None:
+            self._timer_handle.cancel()
+            self._timer_handle = None
+        if self._keepalive_handle is not None:
+            self._keepalive_handle.cancel()
+            self._keepalive_handle = None

--- a/src/telegramify_markdown/stream/draft.py
+++ b/src/telegramify_markdown/stream/draft.py
@@ -1,0 +1,258 @@
+"""DraftStream — strategy facade for Telegram sendMessageDraft / sendRichMessageDraft.
+
+@see docs/adr/002-streaming-draft-support.md §DraftStream
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+from typing import Awaitable, Callable, Literal, Optional
+
+from telegramify_markdown.stream.core import StreamCore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(slots=True)
+class EntityDraftPayload:
+    """Entity mode draft payload — matches sendMessageDraft params."""
+
+    text: str
+    entities: list
+    draft_id: int
+
+
+@dataclasses.dataclass(slots=True)
+class RichDraftPayload:
+    """Rich mode draft payload — matches sendRichMessageDraft params."""
+
+    rich_message: object  # InputRichMessage
+    draft_id: int
+
+
+@dataclasses.dataclass(slots=True)
+class EntityFinalPayload:
+    """Entity mode final payload — matches sendMessage params."""
+
+    text: str
+    entities: list
+
+
+@dataclasses.dataclass(slots=True)
+class RichFinalPayload:
+    """Rich mode final payload — matches sendRichMessage params."""
+
+    rich_message: object  # InputRichMessage
+
+
+class DraftStream:
+    """Strategy facade for streaming via Telegram draft API.
+
+    Assembles StreamCore with:
+    - render = richify or convert (based on mode)
+    - emit = send_draft callback (with thinking delay and sliding window)
+    - finalize = send_final callback
+    - on_cancel = empty draft sender (if cancel_clears_draft)
+    """
+
+    def __init__(
+        self,
+        send_draft: Callable[[EntityDraftPayload | RichDraftPayload], Awaitable[None]],
+        send_final: Callable[[EntityFinalPayload | RichFinalPayload], Awaitable[None]],
+        mode: Literal["rich", "entity"] = "rich",
+        draft_id: Optional[int] = None,
+        interval: float = 0.3,
+        thinking_delay: Optional[float] = 0.5,
+        keepalive_timeout: float = 25.0,
+        cancel_clears_draft: bool = True,
+    ) -> None:
+        if mode not in ("rich", "entity"):
+            raise ValueError(f"mode must be 'rich' or 'entity', got {mode!r}")
+
+        self._send_draft = send_draft
+        self._send_final = send_final
+        self._mode = mode
+        self._draft_id = draft_id if draft_id is not None else (hash(id(self)) & 0x7FFFFFFF | 1)
+        self._thinking_delay = thinking_delay
+        self._cancel_clears_draft = cancel_clears_draft
+
+        # thinking 状态
+        self._first_emit = True
+        self._thinking_suppressed = False
+        self._thinking_timer: asyncio.TimerHandle | None = None
+
+        # 构建 on_cancel
+        on_cancel = self._do_cancel_clear if cancel_clears_draft else None
+
+        self._core = StreamCore(
+            render=self._render,
+            emit=self._emit,
+            finalize=self._finalize_impl,
+            interval=interval,
+            keepalive_timeout=keepalive_timeout,
+            on_cancel=on_cancel,
+        )
+
+    @property
+    def buffer(self) -> str:
+        return self._core.buffer
+
+    @property
+    def state(self) -> str:
+        return self._core.state
+
+    async def __aenter__(self) -> "DraftStream":
+        await self._core.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return await self._core.__aexit__(exc_type, exc_val, exc_tb)
+
+    def feed(self, token: str) -> None:
+        self._core.feed(token)
+
+    async def consume(self, tokens) -> None:
+        await self._core.consume(tokens)
+
+    async def finish(self) -> None:
+        self._cancel_thinking_timer()
+        await self._core.finish()
+
+    async def cancel(self) -> None:
+        self._cancel_thinking_timer()
+        await self._core.cancel()
+
+    def _render(self, buffer: str):
+        """渲染 buffer 为 payload（带 sliding window 截断）。"""
+        if self._mode == "entity":
+            return self._render_entity(buffer)
+        else:
+            return self._render_rich(buffer)
+
+    def _render_entity(self, buffer: str):
+        """Entity 模式渲染：convert() + 尾部 4096 字符截断。"""
+        from telegramify_markdown.converter import convert
+
+        text, entities = convert(buffer)
+
+        # sliding window: 只取尾部 4096 字符
+        # draft 是临时显示，截断后 entities 偏移会失效，直接丢弃
+        if len(text) > 4096:
+            text = text[-4096:]
+            entities = []
+
+        return EntityDraftPayload(
+            text=text,
+            entities=entities,
+            draft_id=self._draft_id,
+        )
+
+    def _render_rich(self, buffer: str):
+        """Rich 模式渲染：richify() + 尾部 32KB 截断。"""
+        from telegramify_markdown.rich import richify, RICH_BYTE_LIMIT
+
+        rich_msg = richify(buffer)
+
+        # sliding window: 如果超出字节限制，截断 HTML
+        if rich_msg.html is not None:
+            encoded = rich_msg.html.encode("utf-8")
+            if len(encoded) > RICH_BYTE_LIMIT:
+                # 从尾部取 RICH_BYTE_LIMIT 字节（在 tag 边界处可能不完美，
+                # 但 draft 是临时的，Telegram 会拒绝无效 HTML 并静默降级）
+                truncated = encoded[-RICH_BYTE_LIMIT:]
+                # 尝试在第一个 '<' 处对齐
+                idx = truncated.find(b"<")
+                if idx > 0:
+                    truncated = truncated[idx:]
+                rich_msg = type(rich_msg)(html=truncated.decode("utf-8", errors="ignore"))
+
+        return RichDraftPayload(
+            rich_message=rich_msg,
+            draft_id=self._draft_id,
+        )
+
+    async def _emit(self, payload) -> None:
+        """Emit 包装：处理 thinking delay。"""
+        if self._first_emit:
+            self._first_emit = False
+            if self._thinking_delay and self._thinking_delay > 0:
+                # 发送空 payload 触发 "Thinking..." 指示器
+                await self._send_thinking()
+                # 标记抑制后续 emit 直到 delay 过期
+                self._thinking_suppressed = True
+                loop = asyncio.get_running_loop()
+                self._thinking_timer = loop.call_later(
+                    self._thinking_delay, self._end_thinking_suppression
+                )
+                return  # 不发送实际内容
+
+        if self._thinking_suppressed:
+            return  # 仍在 thinking delay 期间，跳过
+
+        await self._send_draft(payload)
+
+    async def _send_thinking(self) -> None:
+        """发送 thinking 指示器。
+
+        Entity 模式：空 text 触发 Telegram "Thinking…" 显示。
+        Rich 模式：Telegram 不接受空 HTML，使用 "…" 占位符。
+        """
+        if self._mode == "entity":
+            payload = EntityDraftPayload(text="", entities=[], draft_id=self._draft_id)
+        else:
+            from telegramify_markdown.rich import InputRichMessage
+            payload = RichDraftPayload(
+                rich_message=InputRichMessage(html="<p>\u2026</p>"),
+                draft_id=self._draft_id,
+            )
+        await self._send_draft(payload)
+
+    def _end_thinking_suppression(self) -> None:
+        """Thinking delay 结束，标记 buffer 为 dirty 以触发下次 emit。"""
+        self._thinking_suppressed = False
+        # 让 core 在下一个 tick 重新发送（因为 thinking 期间 emit 被跳过但 dirty 已清除）
+        self._core._dirty = True
+
+    def _cancel_thinking_timer(self) -> None:
+        if self._thinking_timer is not None:
+            self._thinking_timer.cancel()
+            self._thinking_timer = None
+        self._thinking_suppressed = False
+
+    async def _finalize_impl(self, payload) -> None:
+        """Finalize：渲染完整 buffer 并调用 send_final。
+
+        注意：这里只调用 convert/richify 产生单条消息 payload。
+        完整管线（telegramify/telegramify_rich）会返回 list[Text|File|Photo]，
+        涉及多条消息的发送编排，不属于 stream 层职责——由调用者自行处理。
+        """
+        buffer = self._core.buffer
+        if self._mode == "entity":
+            from telegramify_markdown.converter import convert
+            text, entities = convert(buffer)
+            final = EntityFinalPayload(text=text, entities=entities)
+        else:
+            from telegramify_markdown.rich import richify
+            rich_msg = richify(buffer)
+            final = RichFinalPayload(rich_message=rich_msg)
+        await self._send_final(final)
+
+    async def _do_cancel_clear(self) -> None:
+        """取消时发送最小 draft 清除指示器。
+
+        Entity 模式用空 text，Rich 模式用 "…" 占位（Telegram 不接受空 HTML）。
+        """
+        if self._mode == "entity":
+            payload = EntityDraftPayload(text="", entities=[], draft_id=self._draft_id)
+        else:
+            from telegramify_markdown.rich import InputRichMessage
+            payload = RichDraftPayload(
+                rich_message=InputRichMessage(html="<p>\u2026</p>"),
+                draft_id=self._draft_id,
+            )
+        try:
+            await self._send_draft(payload)
+        except Exception:
+            pass  # best-effort

--- a/src/telegramify_markdown/stream/edit.py
+++ b/src/telegramify_markdown/stream/edit.py
@@ -1,0 +1,144 @@
+"""EditStream — strategy facade for group-chat streaming via editMessageText.
+
+For group/channel chats where draft API is unavailable: sends the first message
+via send_message, then updates it with edit_message on each throttle tick.
+
+@see docs/adr/002-streaming-draft-support.md §EditStream
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Literal, Optional
+
+from telegramify_markdown.stream.core import StreamCore
+from telegramify_markdown.stream.draft import (
+    EntityFinalPayload,
+    RichFinalPayload,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class EditStream:
+    """Strategy facade for streaming via editMessageText.
+
+    Assembles StreamCore with:
+    - render = richify or convert (based on mode)
+    - emit = edit_message(message_id, payload) after first send
+    - finalize = one last edit_message with complete content
+    """
+
+    def __init__(
+        self,
+        send_message: Callable,  # async (payload) -> message_id
+        edit_message: Callable,  # async (message_id, payload) -> None
+        mode: Literal["rich", "entity"] = "rich",
+        interval: float = 1.0,
+        keepalive_timeout: float = 25.0,
+    ) -> None:
+        if interval < 1.0:
+            raise ValueError(
+                f"EditStream interval must be >= 1.0s (Telegram edit rate limit), got {interval}"
+            )
+        if mode not in ("rich", "entity"):
+            raise ValueError(f"mode must be 'rich' or 'entity', got {mode!r}")
+
+        self._send_message = send_message
+        self._edit_message = edit_message
+        self._mode = mode
+        self._message_id: Optional[int] = None
+
+        self._core = StreamCore(
+            render=self._render,
+            emit=self._emit,
+            finalize=self._finalize_impl,
+            interval=interval,
+            keepalive_timeout=keepalive_timeout,
+        )
+
+    @property
+    def buffer(self) -> str:
+        return self._core.buffer
+
+    @property
+    def state(self) -> str:
+        return self._core.state
+
+    @property
+    def message_id(self) -> Optional[int]:
+        """已发送消息的 ID（首次 emit 后可用）。"""
+        return self._message_id
+
+    async def __aenter__(self) -> "EditStream":
+        await self._core.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return await self._core.__aexit__(exc_type, exc_val, exc_tb)
+
+    def feed(self, token: str) -> None:
+        self._core.feed(token)
+
+    async def consume(self, tokens) -> None:
+        await self._core.consume(tokens)
+
+    async def finish(self) -> None:
+        await self._core.finish()
+
+    async def cancel(self) -> None:
+        await self._core.cancel()
+
+    def _render(self, buffer: str):
+        """渲染 buffer 为 payload。"""
+        if self._mode == "entity":
+            return self._render_entity(buffer)
+        else:
+            return self._render_rich(buffer)
+
+    def _render_entity(self, buffer: str):
+        """Entity 模式渲染。"""
+        from telegramify_markdown.converter import convert
+
+        text, entities = convert(buffer)
+        return EntityFinalPayload(text=text, entities=entities)
+
+    def _render_rich(self, buffer: str):
+        """Rich 模式渲染。"""
+        from telegramify_markdown.rich import richify
+
+        rich_msg = richify(buffer)
+        return RichFinalPayload(rich_message=rich_msg)
+
+    async def _emit(self, payload) -> None:
+        """First emit sends message; subsequent edits it."""
+        if self._message_id is None:
+            # 首次：发送消息，获取 message_id
+            self._message_id = await self._send_message(payload)
+        else:
+            # 后续：编辑消息
+            await self._edit_message(self._message_id, payload)
+
+    async def _finalize_impl(self, payload) -> None:
+        """Finalize：用完整内容执行最后一次编辑。
+
+        只调用 convert/richify 产生单条消息。完整管线（拆分、Mermaid）
+        不在 stream 层处理——由调用者编排。
+        """
+        buffer = self._core.buffer
+        if self._mode == "entity":
+            from telegramify_markdown.converter import convert
+
+            text, entities = convert(buffer)
+            final = EntityFinalPayload(text=text, entities=entities)
+        else:
+            from telegramify_markdown.rich import richify
+
+            rich_msg = richify(buffer)
+            final = RichFinalPayload(rich_message=rich_msg)
+
+        if self._message_id is None:
+            # 如果从未 emit 过（可能全部在 degraded mode），直接 send
+            self._message_id = await self._send_message(final)
+        else:
+            await self._edit_message(self._message_id, final)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,7 @@ the message content (text + entities) and rejects it with a descriptive
 If the entities were malformed, we'd get a different error first.
 """
 
+import asyncio
 import json
 import os
 import pathlib
@@ -373,6 +374,132 @@ $$E = mc^2$$
         finally:
             for mid in message_ids:
                 _delete_message_best_effort(self.token, self.chat_id, mid)
+
+
+@unittest.skipUnless(
+    os.getenv("TELEGRAM_LIVE_REQUIRED") == "1" and os.getenv("TELEGRAM_CHAT_ID"),
+    "TELEGRAM_LIVE_REQUIRED=1 and TELEGRAM_CHAT_ID required for draft streaming tests",
+)
+class TelegramStreamDraftLiveTest(unittest.IsolatedAsyncioTestCase):
+    """Live test for DraftStream: sends draft updates then a final rich message.
+
+    Proves that:
+    1. sendRichMessageDraft is accepted by the real Telegram API
+    2. DraftStream correctly throttles and accumulates content
+    3. Final sendRichMessage delivers the complete message
+
+    Requires private chat (draft API is private-chat only).
+    """
+
+    def setUp(self):
+        self.token = os.environ["TELEGRAM_BOT_TOKEN"]
+        self.chat_id = os.environ["TELEGRAM_CHAT_ID"]
+        self.message_id = None
+
+    def tearDown(self):
+        _delete_message_best_effort(self.token, self.chat_id, self.message_id)
+
+    async def test_draft_stream_rich_mode(self):
+        """DraftStream(mode='rich') sends drafts and finalizes with sendRichMessage."""
+        from telegramify_markdown.stream.draft import (
+            DraftStream,
+            RichDraftPayload,
+            RichFinalPayload,
+        )
+
+        draft_count = 0
+        draft_errors = []
+
+        async def send_draft(payload: RichDraftPayload) -> None:
+            nonlocal draft_count
+            draft_count += 1
+            api_payload = {
+                "chat_id": self.chat_id,
+                "draft_id": payload.draft_id,
+                "rich_message": payload.rich_message.to_dict(),
+            }
+            try:
+                _post_bot_api_json(self.token, "sendRichMessageDraft", api_payload)
+            except AssertionError as e:
+                draft_errors.append(str(e))
+                raise
+
+        async def send_final(payload: RichFinalPayload) -> None:
+            api_payload = {
+                "chat_id": self.chat_id,
+                "rich_message": payload.rich_message.to_dict(),
+                "disable_notification": True,
+            }
+            result = _post_bot_api_json(self.token, "sendRichMessage", api_payload)
+            self.message_id = result.get("message_id")
+
+        md = "# Stream Test\n\nHello **world**, this is a `streaming` draft.\n\n- Item 1\n- Item 2\n"
+
+        async with DraftStream(
+            send_draft=send_draft,
+            send_final=send_final,
+            mode="rich",
+            interval=0.3,
+            thinking_delay=0.3,
+            keepalive_timeout=25.0,
+        ) as stream:
+            # 模拟逐 token 输入
+            for ch in md:
+                stream.feed(ch)
+                await asyncio.sleep(0.02)
+
+        # Verify results
+        self.assertGreater(draft_count, 0, "Expected at least one draft to be sent")
+        self.assertIsNotNone(self.message_id, "Final message should have been sent")
+        self.assertEqual(len(draft_errors), 0, f"Draft errors: {draft_errors}")
+
+    async def test_draft_stream_entity_mode(self):
+        """DraftStream(mode='entity') sends drafts via sendMessageDraft."""
+        from telegramify_markdown.stream.draft import (
+            DraftStream,
+            EntityDraftPayload,
+            EntityFinalPayload,
+        )
+
+        draft_count = 0
+
+        async def send_draft(payload: EntityDraftPayload) -> None:
+            nonlocal draft_count
+            draft_count += 1
+            api_payload = {
+                "chat_id": self.chat_id,
+                "draft_id": payload.draft_id,
+                "text": payload.text,
+                "entities": [e.to_dict() if hasattr(e, "to_dict") else e for e in payload.entities],
+            }
+            _post_bot_api_json(self.token, "sendMessageDraft", api_payload)
+
+        async def send_final(payload: EntityFinalPayload) -> None:
+            api_payload = {
+                "chat_id": self.chat_id,
+                "text": payload.text,
+                "entities": [e.to_dict() if hasattr(e, "to_dict") else e for e in payload.entities],
+                "disable_notification": True,
+            }
+            result = _post_bot_api_json(self.token, "sendMessage", api_payload)
+            self.message_id = result.get("message_id")
+
+        md = "Hello **bold** and `code` test.\n"
+
+        async with DraftStream(
+            send_draft=send_draft,
+            send_final=send_final,
+            mode="entity",
+            interval=0.3,
+            thinking_delay=None,
+            keepalive_timeout=25.0,
+        ) as stream:
+            for ch in md:
+                stream.feed(ch)
+                await asyncio.sleep(0.02)
+
+        self.assertGreater(draft_count, 0)
+        self.assertIsNotNone(self.message_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,719 @@
+"""Tests for the streaming module — all 8 ADR-002 verification flags.
+
+Flag 1: Re-parse produces valid output on incomplete Markdown
+Flag 2: Throttle respects minimum interval
+Flag 3: Keepalive prevents expiry
+Flag 4: Finalization sends complete message
+Flag 5: EditStream enforces ≥1s interval
+Flag 6: Degraded mode after 3 failures
+Flag 7: Cancellation does not send final message
+Flag 8: Concurrent send guard prevents overlapping emit calls
+
+@see docs/adr/002-streaming-draft-support.md §Verification
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+from telegramify_markdown.stream.core import StreamCore
+from telegramify_markdown.stream.edit import EditStream
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def trivial_render(buf: str) -> str:
+    """简单 render：返回 buffer 本身。"""
+    return buf
+
+
+def upper_render(buf: str) -> str:
+    """render = str.upper，方便验证 payload 来自 render。"""
+    return buf.upper()
+
+
+# ---------------------------------------------------------------------------
+# Flag 1: Re-parse produces valid output on incomplete Markdown
+# ---------------------------------------------------------------------------
+
+
+class TestFlag1IncompleteParsing:
+    """StreamCore should produce valid output even with incomplete Markdown.
+
+    This tests that the render callable (which in real usage calls convert/richify)
+    is always invoked on the full buffer — even when content is mid-syntax.
+    """
+
+    @pytest.mark.asyncio
+    async def test_incomplete_fence(self):
+        """Unclosed code fence should still produce output."""
+        emitted = []
+
+        async def emit(payload):
+            emitted.append(payload)
+
+        async def finalize(payload):
+            pass
+
+        core = StreamCore(render=trivial_render, emit=emit, finalize=finalize, interval=0.05)
+        async with core:
+            # Feed incomplete markdown with CJK and emoji
+            core.feed("```python\ndef hello():\n    print('你好世界 🌍')")
+            # Let at least one tick fire
+            await asyncio.sleep(0.1)
+
+        # At least one emit should have happened with the incomplete markdown
+        assert len(emitted) >= 1
+        assert "你好世界 🌍" in emitted[0]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_emphasis(self):
+        """Unclosed bold/italic should still produce output."""
+        emitted = []
+
+        async def emit(payload):
+            emitted.append(payload)
+
+        async def finalize(payload):
+            pass
+
+        core = StreamCore(render=trivial_render, emit=emit, finalize=finalize, interval=0.05)
+        async with core:
+            core.feed("**これは太字で")
+            await asyncio.sleep(0.1)
+
+        assert len(emitted) >= 1
+        assert "これは太字で" in emitted[0]
+
+    @pytest.mark.asyncio
+    async def test_emoji_and_cjk_in_buffer(self):
+        """Buffer with mixed emoji/CJK/ASCII renders correctly."""
+        emitted = []
+
+        async def emit(payload):
+            emitted.append(payload)
+
+        async def finalize(payload):
+            pass
+
+        core = StreamCore(render=upper_render, emit=emit, finalize=finalize, interval=0.05)
+        async with core:
+            core.feed("Hello 世界 🎉 テスト")
+            await asyncio.sleep(0.1)
+
+        assert len(emitted) >= 1
+        # upper_render uppercases ASCII only
+        assert "HELLO" in emitted[0]
+        assert "世界" in emitted[0]
+        assert "🎉" in emitted[0]
+
+
+# ---------------------------------------------------------------------------
+# Flag 2: Throttle respects minimum interval
+# ---------------------------------------------------------------------------
+
+
+class TestFlag2Throttle:
+    """Throttle should not emit more frequently than interval."""
+
+    @pytest.mark.asyncio
+    async def test_throttle_interval(self):
+        """Emits should be spaced at least `interval` apart."""
+        emit_times = []
+
+        async def emit(payload):
+            emit_times.append(asyncio.get_event_loop().time())
+
+        async def finalize(payload):
+            pass
+
+        interval = 0.15
+        core = StreamCore(
+            render=trivial_render, emit=emit, finalize=finalize, interval=interval
+        )
+        async with core:
+            # Feed multiple tokens rapidly
+            for i in range(20):
+                core.feed(f"token{i} ")
+                await asyncio.sleep(0.02)  # 20 tokens * 20ms = 400ms total
+
+        # Should have ~2-3 emits in 400ms with 150ms interval (not 20)
+        assert len(emit_times) >= 2
+        assert len(emit_times) <= 6  # generous upper bound
+
+        # Verify spacing: consecutive emit times are >= interval apart
+        for i in range(1, len(emit_times)):
+            gap = emit_times[i] - emit_times[i - 1]
+            # Allow 20ms tolerance for async scheduling
+            assert gap >= interval - 0.02, f"Gap {gap:.3f}s < interval {interval}s"
+
+    @pytest.mark.asyncio
+    async def test_burst_absorption(self):
+        """Multiple tokens in one tick interval produce only one emit."""
+        emit_count = 0
+
+        async def emit(payload):
+            nonlocal emit_count
+            emit_count += 1
+
+        async def finalize(payload):
+            pass
+
+        core = StreamCore(
+            render=trivial_render, emit=emit, finalize=finalize, interval=0.2
+        )
+        async with core:
+            # Feed 10 tokens instantly
+            for i in range(10):
+                core.feed(f"t{i}")
+            # Wait for exactly one tick
+            await asyncio.sleep(0.25)
+
+        # Should have emitted exactly once (one tick)
+        assert emit_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Flag 3: Keepalive prevents expiry
+# ---------------------------------------------------------------------------
+
+
+class TestFlag3Keepalive:
+    """Keepalive should fire when no tokens arrive within timeout."""
+
+    @pytest.mark.asyncio
+    async def test_keepalive_fires(self):
+        """After keepalive_timeout with no new tokens, emit is called again."""
+        emitted = []
+
+        async def emit(payload):
+            emitted.append(("emit", asyncio.get_event_loop().time()))
+
+        async def finalize(payload):
+            pass
+
+        # 使用极短的 keepalive_timeout 进行测试
+        core = StreamCore(
+            render=trivial_render,
+            emit=emit,
+            finalize=finalize,
+            interval=0.05,
+            keepalive_timeout=0.2,
+        )
+        async with core:
+            # Feed once, then stop feeding
+            core.feed("initial content")
+            # Wait for first emit
+            await asyncio.sleep(0.1)
+            first_count = len(emitted)
+            assert first_count >= 1
+
+            # Now wait longer than keepalive_timeout without feeding
+            await asyncio.sleep(0.35)
+
+        # Should have received at least one more emit from keepalive
+        assert len(emitted) > first_count
+
+
+# ---------------------------------------------------------------------------
+# Flag 4: Finalization sends complete message
+# ---------------------------------------------------------------------------
+
+
+class TestFlag4Finalization:
+    """finish() should call finalize with the complete rendered buffer."""
+
+    @pytest.mark.asyncio
+    async def test_finalize_called_with_full_buffer(self):
+        """finalize receives the entire accumulated buffer."""
+        finalized = []
+
+        async def emit(payload):
+            pass
+
+        async def finalize(payload):
+            finalized.append(payload)
+
+        core = StreamCore(
+            render=upper_render, emit=emit, finalize=finalize, interval=0.05
+        )
+        async with core:
+            core.feed("hello ")
+            core.feed("world")
+
+        # __aexit__ calls finish(), which calls finalize
+        assert len(finalized) == 1
+        assert finalized[0] == "HELLO WORLD"
+
+    @pytest.mark.asyncio
+    async def test_finalize_after_many_tokens(self):
+        """Finalization runs the full pipeline regardless of intermediate emit state."""
+        emitted = []
+        finalized = []
+
+        async def emit(payload):
+            emitted.append(payload)
+
+        async def finalize(payload):
+            finalized.append(payload)
+
+        core = StreamCore(
+            render=trivial_render, emit=emit, finalize=finalize, interval=0.05
+        )
+        async with core:
+            for i in range(50):
+                core.feed(f"token{i} ")
+            await asyncio.sleep(0.15)
+
+        expected = "".join(f"token{i} " for i in range(50))
+        assert finalized[0] == expected
+
+
+# ---------------------------------------------------------------------------
+# Flag 5: EditStream enforces ≥1s interval
+# ---------------------------------------------------------------------------
+
+
+class TestFlag5EditStreamInterval:
+    """EditStream should reject interval < 1.0."""
+
+    def test_interval_too_low_raises(self):
+        """Interval < 1.0 raises ValueError."""
+        with pytest.raises(ValueError, match="must be >= 1.0s"):
+            EditStream(
+                send_message=AsyncMock(return_value=123),
+                edit_message=AsyncMock(),
+                interval=0.5,
+            )
+
+    def test_interval_at_minimum_ok(self):
+        """Interval = 1.0 is accepted."""
+        stream = EditStream(
+            send_message=AsyncMock(return_value=123),
+            edit_message=AsyncMock(),
+            interval=1.0,
+        )
+        assert stream is not None
+
+    def test_interval_above_minimum_ok(self):
+        """Interval > 1.0 is accepted."""
+        stream = EditStream(
+            send_message=AsyncMock(return_value=123),
+            edit_message=AsyncMock(),
+            interval=2.5,
+        )
+        assert stream is not None
+
+
+# ---------------------------------------------------------------------------
+# Flag 6: Degraded mode after 3 failures
+# ---------------------------------------------------------------------------
+
+
+class TestFlag6DegradedMode:
+    """After 3 consecutive emit failures, enter degraded mode."""
+
+    @pytest.mark.asyncio
+    async def test_degraded_after_three_failures(self):
+        """After 3 emit failures, no more emit calls but finalize still works."""
+        emit_count = 0
+        finalized = []
+
+        async def failing_emit(payload):
+            nonlocal emit_count
+            emit_count += 1
+            raise RuntimeError("network error")
+
+        async def finalize(payload):
+            finalized.append(payload)
+
+        core = StreamCore(
+            render=trivial_render,
+            emit=failing_emit,
+            finalize=finalize,
+            interval=0.05,
+        )
+        async with core:
+            core.feed("content")
+            # Wait enough ticks for 3+ failures
+            await asyncio.sleep(0.25)
+
+            # Feed more content
+            core.feed(" more")
+            await asyncio.sleep(0.15)
+
+        # emit was called exactly 3 times (then degraded mode stops calling)
+        assert emit_count == 3
+
+        # But finalize still fires with complete content
+        assert len(finalized) == 1
+        assert finalized[0] == "content more"
+
+
+# ---------------------------------------------------------------------------
+# Flag 7: Cancellation does not send final message
+# ---------------------------------------------------------------------------
+
+
+class TestFlag7Cancellation:
+    """cancel() should NOT call finalize."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_skips_finalize(self):
+        """Cancellation invokes on_cancel but not finalize."""
+        finalized = []
+        cancelled = []
+
+        async def emit(payload):
+            pass
+
+        async def finalize(payload):
+            finalized.append(payload)
+
+        async def on_cancel():
+            cancelled.append(True)
+
+        core = StreamCore(
+            render=trivial_render,
+            emit=emit,
+            finalize=finalize,
+            interval=0.05,
+            on_cancel=on_cancel,
+        )
+        async with core:
+            core.feed("some content")
+            await asyncio.sleep(0.1)
+            await core.cancel()
+
+        assert len(finalized) == 0
+        assert len(cancelled) == 1
+
+    @pytest.mark.asyncio
+    async def test_cancel_via_exception_in_context_manager(self):
+        """Exception in context triggers cancel, not finalize."""
+        finalized = []
+        cancelled = []
+
+        async def emit(payload):
+            pass
+
+        async def finalize(payload):
+            finalized.append(payload)
+
+        async def on_cancel():
+            cancelled.append(True)
+
+        core = StreamCore(
+            render=trivial_render,
+            emit=emit,
+            finalize=finalize,
+            interval=0.05,
+            on_cancel=on_cancel,
+        )
+        with pytest.raises(ValueError):
+            async with core:
+                core.feed("data")
+                raise ValueError("simulated error")
+
+        assert len(finalized) == 0
+        assert len(cancelled) == 1
+
+
+# ---------------------------------------------------------------------------
+# Flag 8: Concurrent send guard prevents overlapping emit calls
+# ---------------------------------------------------------------------------
+
+
+class TestFlag8ConcurrentGuard:
+    """_sending guard should prevent overlapping emit calls."""
+
+    @pytest.mark.asyncio
+    async def test_no_overlapping_emits(self):
+        """While one emit is in flight, subsequent ticks should skip."""
+        concurrent_count = 0
+        max_concurrent = 0
+        emitted = []
+
+        async def slow_emit(payload):
+            nonlocal concurrent_count, max_concurrent
+            concurrent_count += 1
+            max_concurrent = max(max_concurrent, concurrent_count)
+            emitted.append(payload)
+            await asyncio.sleep(0.1)  # simulate slow network
+            concurrent_count -= 1
+
+        async def finalize(payload):
+            pass
+
+        core = StreamCore(
+            render=trivial_render,
+            emit=slow_emit,
+            finalize=finalize,
+            interval=0.03,  # ticks faster than emit completes
+        )
+        async with core:
+            for i in range(10):
+                core.feed(f"tok{i} ")
+                await asyncio.sleep(0.02)
+
+        # The _sending guard ensures at most 1 concurrent emit
+        assert max_concurrent == 1
+        # Despite 10 tokens, not 10 emits due to throttle + guard
+        assert len(emitted) >= 1
+        assert len(emitted) < 10
+
+
+# ---------------------------------------------------------------------------
+# Integration: EditStream send then edit pattern
+# ---------------------------------------------------------------------------
+
+
+class TestEditStreamIntegration:
+    """EditStream sends first, then edits."""
+
+    @pytest.mark.asyncio
+    async def test_send_then_edit(self):
+        """First emit calls send_message; subsequent call edit_message."""
+        sent = []
+        edited = []
+
+        async def send_message(payload):
+            sent.append(payload)
+            return 42  # message_id
+
+        async def edit_message(msg_id, payload):
+            edited.append((msg_id, payload))
+
+        # Patch convert to avoid needing pyromark for entity mode
+        def mock_convert(buf):
+            return buf, []
+
+        with patch(
+            "telegramify_markdown.stream.edit.EditStream._render",
+            side_effect=lambda self, buf: buf,
+        ):
+            stream = EditStream(
+                send_message=send_message,
+                edit_message=edit_message,
+                mode="entity",
+                interval=1.0,
+            )
+            # 直接测试 _emit 逻辑
+            await stream._emit("first payload")
+            assert stream.message_id == 42
+            assert len(sent) == 1
+
+            await stream._emit("second payload")
+            assert len(edited) == 1
+            assert edited[0] == (42, "second payload")
+
+
+# ---------------------------------------------------------------------------
+# DraftStream strategy-layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestDraftStreamThinkingDelay:
+    """DraftStream thinking delay: first emit sends empty payload, suppresses
+    subsequent emits until delay expires, then resumes normal emit."""
+
+    @pytest.mark.asyncio
+    async def test_thinking_delay_sends_empty_first(self):
+        """First emit should send an empty draft (thinking indicator)."""
+        from telegramify_markdown.stream.draft import DraftStream, EntityDraftPayload
+
+        drafts_sent = []
+
+        async def send_draft(payload):
+            drafts_sent.append(payload)
+
+        async def send_final(payload):
+            pass
+
+        # Use entity mode with a mock convert that avoids pyromark
+        with patch("telegramify_markdown.stream.draft.DraftStream._render_entity") as mock_render:
+            mock_render.return_value = EntityDraftPayload(text="hello", entities=[], draft_id=1)
+
+            stream = DraftStream(
+                send_draft=send_draft,
+                send_final=send_final,
+                mode="entity",
+                interval=0.05,
+                thinking_delay=0.2,
+            )
+            async with stream:
+                stream.feed("hello")
+                # Wait for first tick
+                await asyncio.sleep(0.1)
+
+                # First emit should be the thinking (empty) payload
+                assert len(drafts_sent) >= 1
+                first = drafts_sent[0]
+                assert isinstance(first, EntityDraftPayload)
+                assert first.text == ""
+
+                # During thinking_delay, no real content emitted
+                real_drafts = [d for d in drafts_sent if d.text != ""]
+                assert len(real_drafts) == 0
+
+                # Wait for thinking delay to expire + another tick
+                await asyncio.sleep(0.25)
+
+            # After delay, real content should have been emitted
+            real_drafts = [d for d in drafts_sent if d.text != ""]
+            assert len(real_drafts) >= 1
+
+    @pytest.mark.asyncio
+    async def test_no_thinking_delay(self):
+        """With thinking_delay=None, first emit sends content immediately."""
+        from telegramify_markdown.stream.draft import DraftStream, EntityDraftPayload
+
+        drafts_sent = []
+
+        async def send_draft(payload):
+            drafts_sent.append(payload)
+
+        async def send_final(payload):
+            pass
+
+        with patch("telegramify_markdown.stream.draft.DraftStream._render_entity") as mock_render:
+            mock_render.return_value = EntityDraftPayload(text="content", entities=[], draft_id=1)
+
+            stream = DraftStream(
+                send_draft=send_draft,
+                send_final=send_final,
+                mode="entity",
+                interval=0.05,
+                thinking_delay=None,
+            )
+            async with stream:
+                stream.feed("content")
+                await asyncio.sleep(0.1)
+
+            # No empty "thinking" payload — first draft has content
+            assert len(drafts_sent) >= 1
+            assert all(d.text == "content" for d in drafts_sent)
+
+
+class TestDraftStreamCancelClearsDraft:
+    """cancel_clears_draft sends empty draft on cancel."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_sends_empty_draft(self):
+        """When cancel_clears_draft=True, cancel sends empty payload."""
+        from telegramify_markdown.stream.draft import DraftStream, EntityDraftPayload
+
+        drafts_sent = []
+
+        async def send_draft(payload):
+            drafts_sent.append(payload)
+
+        async def send_final(payload):
+            pass
+
+        with patch("telegramify_markdown.stream.draft.DraftStream._render_entity") as mock_render:
+            mock_render.return_value = EntityDraftPayload(text="hi", entities=[], draft_id=1)
+
+            stream = DraftStream(
+                send_draft=send_draft,
+                send_final=send_final,
+                mode="entity",
+                interval=0.05,
+                thinking_delay=None,
+                cancel_clears_draft=True,
+            )
+            async with stream:
+                stream.feed("hi")
+                await asyncio.sleep(0.1)
+                await stream.cancel()
+
+        # Last draft sent should be the empty clear payload
+        clear_payloads = [d for d in drafts_sent if d.text == "" and d.entities == []]
+        assert len(clear_payloads) >= 1
+
+    @pytest.mark.asyncio
+    async def test_cancel_no_clear_when_disabled(self):
+        """When cancel_clears_draft=False, cancel does NOT send empty payload."""
+        from telegramify_markdown.stream.draft import DraftStream, EntityDraftPayload
+
+        drafts_sent = []
+
+        async def send_draft(payload):
+            drafts_sent.append(payload)
+
+        async def send_final(payload):
+            pass
+
+        with patch("telegramify_markdown.stream.draft.DraftStream._render_entity") as mock_render:
+            mock_render.return_value = EntityDraftPayload(text="hi", entities=[], draft_id=1)
+
+            stream = DraftStream(
+                send_draft=send_draft,
+                send_final=send_final,
+                mode="entity",
+                interval=0.05,
+                thinking_delay=None,
+                cancel_clears_draft=False,
+            )
+            async with stream:
+                stream.feed("hi")
+                await asyncio.sleep(0.1)
+                await stream.cancel()
+
+        # No empty clear payload after the content drafts
+        # (there may still be content emits before cancel)
+        drafts_after_content = drafts_sent[len([d for d in drafts_sent if d.text == "hi"]):]
+        empty_clears = [d for d in drafts_after_content if d.text == ""]
+        assert len(empty_clears) == 0
+
+
+class TestDraftStreamSlidingWindow:
+    """Entity sliding window truncates to 4096 chars."""
+
+    def test_entity_truncation(self):
+        """Text longer than 4096 is truncated to trailing 4096 chars."""
+        from telegramify_markdown.stream.draft import DraftStream, EntityDraftPayload
+
+        # Build a long text and mock convert to return it
+        long_text = "A" * 5000
+        entities = [{"offset": 0, "length": 10, "type": "bold"}]
+
+        with patch("telegramify_markdown.converter.convert", return_value=(long_text, entities)):
+            stream = DraftStream(
+                send_draft=AsyncMock(),
+                send_final=AsyncMock(),
+                mode="entity",
+                thinking_delay=None,
+            )
+            payload = stream._render_entity("x" * 5000)
+
+        assert isinstance(payload, EntityDraftPayload)
+        assert len(payload.text) == 4096
+        # Entities dropped after truncation
+        assert payload.entities == []
+
+    def test_entity_no_truncation_under_limit(self):
+        """Text under 4096 is kept intact with entities."""
+        from telegramify_markdown.stream.draft import DraftStream, EntityDraftPayload
+
+        text = "Hello world"
+        entities = [{"offset": 0, "length": 5, "type": "bold"}]
+
+        with patch("telegramify_markdown.converter.convert", return_value=(text, entities)):
+            stream = DraftStream(
+                send_draft=AsyncMock(),
+                send_final=AsyncMock(),
+                mode="entity",
+                thinking_delay=None,
+            )
+            payload = stream._render_entity("Hello world")
+
+        assert payload.text == "Hello world"
+        assert payload.entities == entities


### PR DESCRIPTION
## Summary

- Two-layer async streaming architecture for LLM token-by-token output via Telegram draft API
  - `StreamCore[T]`: protocol-agnostic throttled buffer (state machine, keepalive, degraded mode, concurrent send guard)
  - `DraftStream`: facade for `sendMessageDraft` / `sendRichMessageDraft` (private chats, thinking indicator, sliding window truncation)
  - `EditStream`: facade for send-then-edit pattern (group chats, ≥1.0s interval enforced)
- 22 unit tests covering all 8 ADR verification flags + DraftStream strategy layer
- Live integration tests against real Telegram Bot API (`pdm run test-live-stream`)
- README updated with streaming usage section; "For AI Assistants" section streamlined to reference `llms.txt`

## Test plan

- [x] `pdm run pytest tests/test_stream.py -v` — 22 passed
- [x] `pdm run test` — 244 passed (full regression, no breakage)
- [x] `pdm run test-live-stream` — entity + rich mode pass against real Telegram API
- [x] `playground/stream_draft_case.py` — 15 drafts sent, final message delivered (message_id=179)
- [ ] Reviewer: verify streaming behavior in Telegram client (run `pdm run python playground/stream_draft_case.py`)