### PR TITLE
feat: add entities_to_markdown() for Rich Message markdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ poetry add "telegramify-markdown[mermaid]"
 - If your middleware only supports `parse_mode="MarkdownV2"` (no `entities` parameter) → use **`markdownify()`**
 - If you need to split long MarkdownV2 output safely → use **`split_markdownv2()`**
 - If you need finer control over the reverse conversion → use **`entities_to_markdownv2()`**
+- If you have `(text, entities)` from Telegram and want standard Markdown (no MarkdownV2 escaping) for Rich Messages → use **`entities_to_markdown()`**
 - If you want Telegram Bot API 10.1 structured Rich Messages → use **`richify()`**
 - If you need to split long Rich Messages automatically → use **`telegramify_rich()`**
 
@@ -318,6 +319,33 @@ bot.send_message(chat_id, mdv2, parse_mode="MarkdownV2")
 
 This handles all MarkdownV2 escaping rules correctly (different escaping for normal text, code/pre blocks, and URLs).
 
+### `entities_to_markdown()` — reverse conversion to standard Markdown
+
+If you have `(text, entities)` from Telegram (e.g., from `update.message`) and want a standard Markdown
+string without MarkdownV2 escaping — for use with `InputRichMessage(markdown=...)` or any standard
+Markdown consumer:
+
+```python
+from telegramify_markdown import entities_to_markdown, InputRichMessage
+import requests
+
+# text and entities come from Telegram's update.message
+md = entities_to_markdown(update.message.text, [
+    MessageEntity(**e) for e in update.message.entities
+])
+
+payload = InputRichMessage(markdown=md).to_dict()
+requests.post(
+    f"https://api.telegram.org/bot{token}/sendRichMessage",
+    json={"chat_id": chat_id, "rich_message": payload},
+    timeout=30,
+)
+```
+
+Unlike `entities_to_markdownv2()`, this does not escape `#`, `.`, `!`, etc. — the output is plain
+standard Markdown. Code/pre blocks and URL internals are still escaped because those are required by
+Markdown syntax itself.
+
 ## ⚙️ Configuration
 
 Customize heading symbols, link symbols, expandable citation behavior, and Mermaid rendering:
@@ -431,6 +459,17 @@ and only need splitting.
 
 Reverse conversion: takes plain text and entities, returns a MarkdownV2 string with correct escaping.
 Useful when you already have `(text, entities)` from `convert()` and need a MarkdownV2 string.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `text` | `str` | required | Plain text content |
+| `entities` | `list[MessageEntity] \| None` | `None` | Entity list (UTF-16 offsets) |
+
+### `entities_to_markdown(text, entities=None) -> str`
+
+Reverse conversion: takes plain text and entities, returns a standard Markdown string without
+MarkdownV2 escaping. Useful when you have `(text, entities)` from Telegram and want to send them
+via `InputRichMessage(markdown=...)`.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -343,8 +343,10 @@ requests.post(
 ```
 
 Unlike `entities_to_markdownv2()`, this does not escape `#`, `.`, `!`, etc. — the output is plain
-standard Markdown. Code/pre blocks and URL internals are still escaped because those are required by
-Markdown syntax itself.
+standard Markdown. Formatting markers follow CommonMark conventions (`**bold**`, `~~strikethrough~~`)
+rather than MarkdownV2 (`*bold*`, `~strikethrough~`). Underline entities degrade to plain text since
+standard Markdown has no underline syntax. Code/pre blocks and URL internals are still escaped
+because those are required by Markdown syntax itself.
 
 ## ⚙️ Configuration
 

--- a/src/telegramify_markdown/__init__.py
+++ b/src/telegramify_markdown/__init__.py
@@ -9,13 +9,14 @@ from telegramify_markdown import config
 from telegramify_markdown.converter import convert as convert
 from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
 from telegramify_markdown.content import ContentType, ContentTypes, ContentTrace, File, Photo, RichMessage, Text
-from telegramify_markdown.mdv2 import entities_to_markdownv2, split_markdownv2
+from telegramify_markdown.mdv2 import entities_to_markdown, entities_to_markdownv2, split_markdownv2
 from telegramify_markdown.rich import InputRichMessage, richify, split_rich, telegramify_rich
 
 __all__ = [
     "convert",
     "telegramify",
     "entities_to_markdownv2",
+    "entities_to_markdown",
     "split_markdownv2",
     "markdownify",
     "standardize",

--- a/src/telegramify_markdown/mdv2.py
+++ b/src/telegramify_markdown/mdv2.py
@@ -12,6 +12,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
 
 # MarkdownV2 普通文本需要转义的 20 个字符
@@ -82,17 +84,26 @@ _SIMPLE_MARKERS: dict[str, tuple[str, str]] = {
 _CODE_ENTITY_TYPES = frozenset({"code", "pre"})
 
 
-def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = None) -> str:
-    """将 (text, entities) 转换为 MarkdownV2 格式字符串。
+def _format_entities(
+    text: str,
+    entities: list[MessageEntity] | None,
+    *,
+    text_escape_fn: Callable[[str], str],
+) -> str:
+    """扫描线核心算法：将 (text, entities) 合并为带格式标记的字符串。
+
+    code/pre 内部统一使用 _escape_code，URL 内部统一使用 _escape_url，
+    普通文本区域使用 text_escape_fn 控制转义策略。
 
     :param text: 纯文本内容
     :param entities: MessageEntity 列表（UTF-16 offset/length）
-    :return: 可直接用于 Telegram parse_mode="MarkdownV2" 的字符串
+    :param text_escape_fn: 普通文本区域的转义函数
+    :return: 带格式标记的字符串
     """
     if not text:
         return ""
     if not entities:
-        return _escape_markdownv2(text)
+        return text_escape_fn(text)
 
     utf16_to_py = _utf16_offset_to_pyindex(text)
 
@@ -167,7 +178,7 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
 
     def _emit_segment(segment: str, seg_start_py: int) -> None:
         """输出文本段，在 \\n 后插入 blockquote 前缀。"""
-        escape_fn = _escape_code if active_code_entities else _escape_markdownv2
+        escape_fn = _escape_code if active_code_entities else text_escape_fn
         if not bq_ranges:
             parts.append(escape_fn(segment))
             return
@@ -259,6 +270,29 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
         _emit_text_between(prev_py, len(text), previous_event_closed_pre)
 
     return "".join(parts)
+
+
+def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = None) -> str:
+    """将 (text, entities) 转换为 MarkdownV2 格式字符串。
+
+    :param text: 纯文本内容
+    :param entities: MessageEntity 列表（UTF-16 offset/length）
+    :return: 可直接用于 Telegram parse_mode="MarkdownV2" 的字符串
+    """
+    return _format_entities(text, entities, text_escape_fn=_escape_markdownv2)
+
+
+def entities_to_markdown(text: str, entities: list[MessageEntity] | None = None) -> str:
+    """将 (text, entities) 合并回标准 Markdown 字符串（不转义普通文本）。
+
+    适用于 ``InputRichMessage(markdown=...)`` 或任何接受标准 Markdown 的场景。
+    code/pre 和 URL 内部的必要转义仍然保留，因为这些是 Markdown 语法的物理约束。
+
+    :param text: 纯文本内容
+    :param entities: MessageEntity 列表（UTF-16 offset/length）
+    :return: 标准 Markdown 字符串
+    """
+    return _format_entities(text, entities, text_escape_fn=lambda x: x)
 
 
 def split_markdownv2(

--- a/src/telegramify_markdown/mdv2.py
+++ b/src/telegramify_markdown/mdv2.py
@@ -71,12 +71,22 @@ def _utf16_offset_to_pyindex(text: str) -> dict[int, int]:
     return mapping
 
 
-# entity type → (open_tag, close_tag) 的简单标记映射
-_SIMPLE_MARKERS: dict[str, tuple[str, str]] = {
+# MarkdownV2 标记（Telegram parse_mode="MarkdownV2" 规范）
+_MDV2_MARKERS: dict[str, tuple[str, str]] = {
     "bold": ("*", "*"),
     "italic": ("_", "_"),
     "underline": ("__", "__"),
     "strikethrough": ("~", "~"),
+    "spoiler": ("||", "||"),
+}
+
+# CommonMark 标记（用于 InputRichMessage(markdown=...)）
+# bold 用双星号、strikethrough 用双波浪线（CommonMark/GFM 语义）。
+# underline 在标准 Markdown 中无对应标记，退化为纯文本。
+_COMMONMARK_MARKERS: dict[str, tuple[str, str]] = {
+    "bold": ("**", "**"),
+    "italic": ("_", "_"),
+    "strikethrough": ("~~", "~~"),
     "spoiler": ("||", "||"),
 }
 
@@ -89,15 +99,18 @@ def _format_entities(
     entities: list[MessageEntity] | None,
     *,
     text_escape_fn: Callable[[str], str],
+    markers: dict[str, tuple[str, str]],
 ) -> str:
     """扫描线核心算法：将 (text, entities) 合并为带格式标记的字符串。
 
     code/pre 内部统一使用 _escape_code，URL 内部统一使用 _escape_url，
-    普通文本区域使用 text_escape_fn 控制转义策略。
+    普通文本区域使用 text_escape_fn 控制转义策略，
+    entity 标记使用 markers 控制风格。
 
     :param text: 纯文本内容
     :param entities: MessageEntity 列表（UTF-16 offset/length）
     :param text_escape_fn: 普通文本区域的转义函数
+    :param markers: entity type → (open, close) 标记映射
     :return: 带格式标记的字符串
     """
     if not text:
@@ -247,7 +260,7 @@ def _format_entities(
                 continue
             ent_id = id(ent)
             active_code_entities.discard(ent_id)
-            _emit_tag(_get_close_tag(ent), pos)
+            _emit_tag(_get_close_tag(ent, markers), pos)
             if ent.type == "pre":
                 closed_pre_at_pos = True
 
@@ -260,7 +273,7 @@ def _format_entities(
             ent_id = id(ent)
             if ent.type in _CODE_ENTITY_TYPES:
                 active_code_entities.add(ent_id)
-            _emit_tag(_get_open_tag(ent), pos)
+            _emit_tag(_get_open_tag(ent, markers), pos)
 
         previous_event_closed_pre = closed_pre_at_pos
         prev_py = pos
@@ -279,7 +292,7 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
     :param entities: MessageEntity 列表（UTF-16 offset/length）
     :return: 可直接用于 Telegram parse_mode="MarkdownV2" 的字符串
     """
-    return _format_entities(text, entities, text_escape_fn=_escape_markdownv2)
+    return _format_entities(text, entities, text_escape_fn=_escape_markdownv2, markers=_MDV2_MARKERS)
 
 
 def entities_to_markdown(text: str, entities: list[MessageEntity] | None = None) -> str:
@@ -292,7 +305,7 @@ def entities_to_markdown(text: str, entities: list[MessageEntity] | None = None)
     :param entities: MessageEntity 列表（UTF-16 offset/length）
     :return: 标准 Markdown 字符串
     """
-    return _format_entities(text, entities, text_escape_fn=lambda x: x)
+    return _format_entities(text, entities, text_escape_fn=lambda x: x, markers=_COMMONMARK_MARKERS)
 
 
 def split_markdownv2(
@@ -341,10 +354,10 @@ def split_markdownv2(
     return chunks
 
 
-def _get_open_tag(ent: MessageEntity) -> str:
+def _get_open_tag(ent: MessageEntity, markers: dict[str, tuple[str, str]]) -> str:
     """获取 entity 的开始标记。"""
-    if ent.type in _SIMPLE_MARKERS:
-        return _SIMPLE_MARKERS[ent.type][0]
+    if ent.type in markers:
+        return markers[ent.type][0]
     if ent.type == "code":
         return "`"
     if ent.type == "pre":
@@ -363,10 +376,10 @@ def _get_open_tag(ent: MessageEntity) -> str:
     return ""
 
 
-def _get_close_tag(ent: MessageEntity) -> str:
+def _get_close_tag(ent: MessageEntity, markers: dict[str, tuple[str, str]]) -> str:
     """获取 entity 的结束标记。"""
-    if ent.type in _SIMPLE_MARKERS:
-        return _SIMPLE_MARKERS[ent.type][1]
+    if ent.type in markers:
+        return markers[ent.type][1]
     if ent.type == "code":
         return "`"
     if ent.type == "pre":

--- a/tests/test_mdv2.py
+++ b/tests/test_mdv2.py
@@ -479,13 +479,26 @@ class EntitiesToMarkdownTest(unittest.TestCase):
         text = "hello world"
         entities = [MessageEntity(type="bold", offset=0, length=5)]
         result = entities_to_markdown(text, entities)
-        self.assertEqual(result, "*hello* world")
+        self.assertEqual(result, "**hello** world")
 
     def test_italic(self):
         text = "hello world"
         entities = [MessageEntity(type="italic", offset=0, length=5)]
         result = entities_to_markdown(text, entities)
         self.assertEqual(result, "_hello_ world")
+
+    def test_strikethrough(self):
+        text = "deleted"
+        entities = [MessageEntity(type="strikethrough", offset=0, length=7)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "~~deleted~~")
+
+    def test_underline_degrades_to_plain(self):
+        """underline 在标准 Markdown 中无对应标记，退化为纯文本"""
+        text = "underlined"
+        entities = [MessageEntity(type="underline", offset=0, length=10)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "underlined")
 
     def test_issue_120_case(self):
         """issue #120：# 和 . 不应被转义，格式标记正常插入"""
@@ -495,7 +508,7 @@ class EntitiesToMarkdownTest(unittest.TestCase):
             MessageEntity(type="italic", offset=20, length=6),
         ]
         result = entities_to_markdown(text, entities)
-        self.assertEqual(result, "# Hello World.\n*bold* _italic_")
+        self.assertEqual(result, "# Hello World.\n**bold** _italic_")
 
     def test_code_internal_escape_preserved(self):
         """code 内部仍转义 ` 和 \\"""
@@ -525,7 +538,7 @@ class EntitiesToMarkdownTest(unittest.TestCase):
             MessageEntity(type="italic", offset=5, length=6),
         ]
         result = entities_to_markdown(text, entities)
-        self.assertEqual(result, "*bold _italic_ end*")
+        self.assertEqual(result, "**bold _italic_ end**")
 
     def test_adjacent_entities(self):
         text = "bolditalic"
@@ -534,7 +547,7 @@ class EntitiesToMarkdownTest(unittest.TestCase):
             MessageEntity(type="italic", offset=4, length=6),
         ]
         result = entities_to_markdown(text, entities)
-        self.assertEqual(result, "*bold*_italic_")
+        self.assertEqual(result, "**bold**_italic_")
 
     def test_pre_with_lang(self):
         text = "print(1)"
@@ -559,7 +572,7 @@ class EntitiesToMarkdownTest(unittest.TestCase):
         text = "📌bold"
         entities = [MessageEntity(type="bold", offset=2, length=4)]
         result = entities_to_markdown(text, entities)
-        self.assertEqual(result, "📌*bold*")
+        self.assertEqual(result, "📌**bold**")
 
     def test_roundtrip_from_convert(self):
         """convert() → entities_to_markdown 应保留原始结构"""
@@ -567,7 +580,7 @@ class EntitiesToMarkdownTest(unittest.TestCase):
 
         text, entities = convert("**bold** and _italic_")
         result = entities_to_markdown(text, entities)
-        self.assertIn("*bold*", result)
+        self.assertIn("**bold**", result)
         self.assertIn("_italic_", result)
 
 

--- a/tests/test_mdv2.py
+++ b/tests/test_mdv2.py
@@ -8,6 +8,7 @@ from telegramify_markdown.mdv2 import (
     _escape_code,
     _escape_markdownv2,
     _escape_url,
+    entities_to_markdown,
     entities_to_markdownv2,
     split_markdownv2,
 )
@@ -451,6 +452,123 @@ class PreBeforeBlockquoteTest(unittest.TestCase):
         ]
         result = entities_to_markdownv2(text, entities)
         self.assertIn(">quoted", result)
+
+
+# ── 第四层：entities_to_markdown（标准 Markdown，不转义普通文本）──
+
+
+class EntitiesToMarkdownTest(unittest.TestCase):
+    """entities_to_markdown：合并回标准 Markdown，不转义普通文本。"""
+
+    def test_no_escape_on_special_chars(self):
+        """# . ! 等普通文本字符不应被转义（issue #120 核心）"""
+        text = "# Hello World."
+        result = entities_to_markdown(text, [])
+        self.assertEqual(result, "# Hello World.")
+
+    def test_none_entities(self):
+        """无 entities 时不转义"""
+        text = "hello *world* [x](y)"
+        result = entities_to_markdown(text, None)
+        self.assertEqual(result, "hello *world* [x](y)")
+
+    def test_empty_text(self):
+        self.assertEqual(entities_to_markdown("", []), "")
+
+    def test_bold(self):
+        text = "hello world"
+        entities = [MessageEntity(type="bold", offset=0, length=5)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "*hello* world")
+
+    def test_italic(self):
+        text = "hello world"
+        entities = [MessageEntity(type="italic", offset=0, length=5)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "_hello_ world")
+
+    def test_issue_120_case(self):
+        """issue #120：# 和 . 不应被转义，格式标记正常插入"""
+        text = "# Hello World.\nbold italic"
+        entities = [
+            MessageEntity(type="bold", offset=15, length=4),
+            MessageEntity(type="italic", offset=20, length=6),
+        ]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "# Hello World.\n*bold* _italic_")
+
+    def test_code_internal_escape_preserved(self):
+        """code 内部仍转义 ` 和 \\"""
+        text = "a`b"
+        entities = [MessageEntity(type="code", offset=0, length=3)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "`a\\`b`")
+
+    def test_code_special_chars_not_escaped(self):
+        """code 内的 * _ 等不转义"""
+        text = "a*b_c"
+        entities = [MessageEntity(type="code", offset=0, length=5)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "`a*b_c`")
+
+    def test_url_internal_escape_preserved(self):
+        """URL 内部仍转义 ) 和 \\"""
+        text = "link"
+        entities = [MessageEntity(type="text_link", offset=0, length=4, url="https://a.com/b(c)")]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "[link](https://a.com/b(c\\))")
+
+    def test_nested_bold_italic(self):
+        text = "bold italic end"
+        entities = [
+            MessageEntity(type="bold", offset=0, length=15),
+            MessageEntity(type="italic", offset=5, length=6),
+        ]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "*bold _italic_ end*")
+
+    def test_adjacent_entities(self):
+        text = "bolditalic"
+        entities = [
+            MessageEntity(type="bold", offset=0, length=4),
+            MessageEntity(type="italic", offset=4, length=6),
+        ]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "*bold*_italic_")
+
+    def test_pre_with_lang(self):
+        text = "print(1)"
+        entities = [MessageEntity(type="pre", offset=0, length=8, language="python")]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "```python\nprint(1)\n```")
+
+    def test_blockquote_single_line(self):
+        text = "quoted text"
+        entities = [MessageEntity(type="blockquote", offset=0, length=11)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, ">quoted text")
+
+    def test_blockquote_multi_line(self):
+        text = "line1\nline2\nline3"
+        entities = [MessageEntity(type="blockquote", offset=0, length=utf16_len(text))]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, ">line1\n>line2\n>line3")
+
+    def test_emoji_utf16_offset(self):
+        """emoji 的 UTF-16 offset 正确性"""
+        text = "📌bold"
+        entities = [MessageEntity(type="bold", offset=2, length=4)]
+        result = entities_to_markdown(text, entities)
+        self.assertEqual(result, "📌*bold*")
+
+    def test_roundtrip_from_convert(self):
+        """convert() → entities_to_markdown 应保留原始结构"""
+        from telegramify_markdown.converter import convert
+
+        text, entities = convert("**bold** and _italic_")
+        result = entities_to_markdown(text, entities)
+        self.assertIn("*bold*", result)
+        self.assertIn("_italic_", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `entities_to_markdown(text, entities)` — merges `(text, entities)` back into standard Markdown without MarkdownV2 escaping
- Extract shared `_format_entities()` core from `entities_to_markdownv2()` to avoid algorithm duplication; both functions are thin wrappers over the same scanline engine, differing only in text-escape strategy
- Code/pre and URL internal escaping is preserved (physical Markdown constraint)

Closes #120

## Context

Issue #120 requested a way to merge Telegram's `(text, entities)` back into a Markdown string for `InputRichMessage(markdown=...)`. The existing `entities_to_markdownv2()` escapes `#`, `.`, `!`, etc. (required by MarkdownV2), which is unnecessary and unwanted for Rich Message markdown mode.

## Test plan

- [x] `pdm run test` — 260 tests pass (3 skipped: Mermaid optional deps)
- [x] New `EntitiesToMarkdownTest` class with 18 tests covering:
  - Issue #120 exact case (`#` and `.` not escaped)
  - Bold/italic/code/pre/text_link markers
  - Code internal escaping preserved (`` ` `` and `\`)
  - URL internal escaping preserved (`)` and `\`)
  - Nested/adjacent entities
  - Blockquote prefix injection
  - UTF-16 emoji offset correctness
  - Roundtrip from `convert()`
- [ ] Live validation against `sendRichMessage` (requires `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID`) — recommended before merge