### PR TITLE
Bug fix, complexity and configuration pass (v1.3.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ always:
 - Keep core runtime dependencies minimal. The core converter depends on pyromark; Mermaid rendering uses optional Pillow and aiohttp.
 - Preserve all Telegram entity offsets and lengths as UTF-16 code units.
 - Add public API docstrings.
-- Prefer Chinese comments when comments are needed.
+- Write code comments and docstrings in English. Chat with the user in Chinese.
 - Do not create a PR for Rich Message changes until `pdm run test-live-rich` passes against the real Telegram Bot API with `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID`.
 
 ask first:

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ This handles all MarkdownV2 escaping rules correctly (different escaping for nor
 
 ## ⚙️ Configuration
 
-Customize heading symbols, link symbols, expandable citation behavior, and Mermaid rendering:
+Customize heading symbols, link symbols, list markers, expandable citation behavior, and Mermaid rendering:
 
 ```python
 from telegramify_markdown.config import get_runtime_config
@@ -328,6 +328,8 @@ from telegramify_markdown.config import get_runtime_config
 cfg = get_runtime_config()
 cfg.markdown_symbol.heading_level_1 = "📌"
 cfg.markdown_symbol.link = "🔗"
+cfg.markdown_symbol.unordered_list_item = "-"   # default "⦁"; try "•", "*", …
+cfg.markdown_symbol.ordered_list_suffix = "."   # renders "1. item"; ")" gives "1) item"
 cfg.cite_expandable = True  # Long quotes become expandable_blockquote
 cfg.mermaid.width = 1280
 cfg.mermaid.scale = 2
@@ -340,6 +342,31 @@ cfg.mermaid.image_type = "webp"
 # cfg.markdown_symbol.heading_level_3 = ""
 # cfg.markdown_symbol.heading_level_4 = ""
 ```
+
+List markers are plain text and carry no entity. Task list items keep using
+`task_completed` / `task_uncompleted` and replace the list marker entirely.
+
+`get_runtime_config()` returns a **process-global** config. Setting it once at
+startup is the common case. It is shared mutable state, so a bot that varies
+symbols per chat must not mutate it inside a handler — concurrent requests would
+read each other's values. Use an independent config instead and pass it in:
+
+```python
+from telegramify_markdown import RenderConfig, telegramify
+
+cfg = RenderConfig.isolated()          # library defaults, independent
+# cfg = get_runtime_config().copy()    # or: start from the current global values
+cfg.markdown_symbol.unordered_list_item = "-"
+
+boxes = await telegramify(markdown, config=cfg)
+```
+
+`config=` is accepted by `convert()`, `convert_with_segments()`, `markdownify()`,
+`standardize()`, and `telegramify()` (which also applies `cfg.mermaid` to
+rendered diagrams). `richify()` and `telegramify_rich()` take no config —
+Rich HTML emits structural tags and reads no symbols.
+
+See [docs/prd/render-config.md](./docs/prd/render-config.md) for the full contract.
 
 `telegramify()` picks up Mermaid settings from the runtime config. The default Mermaid width is `1000`.
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -10,6 +10,7 @@ chosen and what was rejected. The two link in one direction: ADR frontmatter
 
 | PRD | Boundary | Owner |
 |---|---|---|
+| [render-config](./render-config.md) | Symbol/Mermaid configuration and its scoping | `src/telegramify_markdown/config.py` |
 | [rich-message](./rich-message.md) | Telegram Bot API 10.1 Rich Message output | `src/telegramify_markdown/rich.py` |
 
 ## System Architecture

--- a/docs/prd/render-config.md
+++ b/docs/prd/render-config.md
@@ -1,0 +1,139 @@
+# Render Configuration PRD
+
+## Product Boundary
+
+Owns how a caller chooses the symbols and Mermaid settings a conversion uses,
+and how those choices are scoped. Covers `src/telegramify_markdown/config.py`
+and the `config=` parameter on every conversion entry point.
+
+Does not own what the symbols mean during conversion (that is the converter's
+event semantics), nor Rich Message output, which renders structural HTML tags
+and takes no symbol configuration.
+
+## Users
+
+| Actor | Need |
+|---|---|
+| Bot developer, single style | Set heading/list/rule symbols once at startup and forget them |
+| Bot developer, per-chat style | Render concurrent requests with different symbols without cross-contamination |
+| Library maintainer | Configure symbols in a test without leaking state into the next test |
+
+## Data Flow Model
+
+```text
+RenderConfig  ──┬── global instance ── get_runtime_config() / RenderConfig()
+                └── independent    ── RenderConfig.isolated() / cfg.copy()
+                                       │
+                        config= ───────┴──> convert()
+                                            convert_with_segments()
+                                            markdownify() / standardize()
+                                            telegramify() ──> process_markdown()
+                                                               └─> mermaid URL builders
+```
+
+### Data-Centered Decisions
+
+**Authority.** A `RenderConfig` instance is the sole authority for the symbols
+and Mermaid settings of the conversions it is passed to. Passing no config means
+the global instance is the authority.
+
+**Value semantics.** `Symbol` and `Mermaid` are mutable value holders owned by
+exactly one `RenderConfig`. `isolated()` builds them fresh from defaults;
+`copy()` deep-copies them from an existing config. Neither shares a holder with
+another config, so mutating one config can never be observed through another.
+
+**Scope is the caller's choice, not the library's.** The global instance exists
+because a single-style bot should not have to thread a config through its call
+stack. It is shared mutable state: a value written to it is visible to every
+concurrent conversion that does not pass its own config. Callers that vary
+symbols per request must own an independent config; the library cannot infer
+request boundaries.
+
+## Outcomes
+
+| Outcome | Proof |
+|---|---|
+| A single-style bot configures once at startup | `get_runtime_config()` mutation is visible to later conversions that pass no config |
+| Concurrent requests can use different symbols | Two threads rendering with two `isolated()` configs each get their own marker |
+| Existing 1.x callers keep working unchanged | `RenderConfig()` returns the global instance; repeated construction does not reset settings |
+| A config reaches every documented surface | `config=` changes output for `convert`, `markdownify`, `telegramify`, and Mermaid URLs |
+
+## Public Contract
+
+### Obtaining a config
+
+| Call | Returns |
+|---|---|
+| `get_runtime_config()` | The process-global instance |
+| `RenderConfig()` | The process-global instance (same object) |
+| `RenderConfig.isolated()` | A new instance carrying library defaults |
+| `cfg.copy()` | A new instance carrying `cfg`'s current values |
+
+`RenderConfig` is a class: `isinstance(cfg, RenderConfig)` is valid, and
+`RenderConfig` is usable in type annotations.
+
+Constructing `RenderConfig()` more than once must not reset already-configured
+values — the global instance is initialised exactly once per process.
+
+### Configurable fields
+
+`cfg.markdown_symbol` (`Symbol`), read-only attribute holding mutable fields:
+
+| Field | Default | Applies to |
+|---|---|---|
+| `heading_level_1` … `heading_level_6` | `📌` `✏️` `📚` `🔖` `""` `""` | Heading text prefix |
+| `image` | `🖼` | Image placeholder |
+| `link` | `🔗` | Link symbol |
+| `task_completed` / `task_uncompleted` | `✅` / `☑️` | Task list markers, replacing the list marker |
+| `horizontal_rule` | `————————` | Thematic break |
+| `unordered_list_item` | `⦁` | Unordered list marker, written after the indent |
+| `ordered_list_suffix` | `.` | Follows the item number, as in `1. ` |
+
+`cfg.mermaid` (`Mermaid`), read-only attribute holding `theme`, `width`,
+`scale`, `image_type`.
+
+`cfg.cite_expandable` (`bool`, read/write): long blockquotes become
+`expandable_blockquote`.
+
+List markers are plain text and carry no entity.
+
+### Accepting a config
+
+| Entry point | Effect of `config=` |
+|---|---|
+| `convert()` / `convert_with_segments()` | Symbols used while walking events |
+| `markdownify()` / `standardize()` | Symbols, before MarkdownV2 rendering |
+| `telegramify()` | Symbols, plus Mermaid theme/width/scale/type for rendered diagrams |
+| `richify()` / `telegramify_rich()` | None — Rich HTML emits structural tags and reads no symbols |
+
+Omitting `config=` uses the global instance.
+
+## Error Semantics
+
+Symbol fields are unvalidated strings. An empty string renders no prefix; that
+is the documented way to suppress heading emoji. A multi-character marker is
+written verbatim.
+
+Mutating a config concurrently with a conversion that reads it is a caller
+error; the library performs no locking. Independent configs are the mechanism
+for concurrent use.
+
+## Acceptance Cases
+
+| Case | Expectation |
+|---|---|
+| `RenderConfig() is get_runtime_config()` | True |
+| `RenderConfig()` twice after setting a field | Field keeps its set value |
+| `isinstance(get_runtime_config(), RenderConfig)` | True |
+| `isolated()` after mutating the global | Carries library defaults, not the global's values |
+| Mutating an `isolated()` config | Global is unchanged |
+| `copy()` of a mutated global | Carries the global's values, then diverges independently |
+| Two threads, two `isolated()` configs, same markdown | Each renders its own marker |
+| `telegramify(config=cfg)` with `unordered_list_item = "-"` | Output uses `-`, global unchanged |
+| `get_mermaid_ink_url(diagram, cfg)` with `width = 4242` | URL carries `width=4242`; omitting `cfg` carries the global width |
+
+## External Authority
+
+Telegram imposes no symbol vocabulary: headings, list markers, and thematic
+rules do not exist in the entity model, so every symbol here is a rendering
+choice this library makes on the caller's behalf, not an API requirement.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -123,8 +123,29 @@ cfg.markdown_symbol.link = "🔗"
 cfg.markdown_symbol.image = "🖼"
 cfg.markdown_symbol.task_completed = "✅"
 cfg.markdown_symbol.task_uncompleted = "☑️"
+cfg.markdown_symbol.unordered_list_item = "⦁"  # or "-", "•", "*"
+cfg.markdown_symbol.ordered_list_suffix = "."  # renders "1. item"
 cfg.cite_expandable = True  # long quotes become expandable_blockquote
 ```
+
+get_runtime_config() returns a process-global config. It is shared mutable
+state: do not mutate it inside a request handler if concurrent requests use
+different symbols. Use an independent config and pass it in instead.
+
+```python
+from telegramify_markdown import RenderConfig
+
+cfg = RenderConfig.isolated()          # library defaults, independent
+# cfg = get_runtime_config().copy()    # or start from current global values
+cfg.markdown_symbol.unordered_list_item = "-"
+
+boxes = await telegramify(markdown, config=cfg)
+```
+
+config= is accepted by convert(), convert_with_segments(), markdownify(),
+standardize(), and telegramify() (which also applies cfg.mermaid to rendered
+diagrams). richify() and telegramify_rich() take no config: Rich HTML emits
+structural tags and reads no symbols.
 
 ## API Reference
 
@@ -135,13 +156,13 @@ Synchronous. Converts a Markdown string to plain text and a list of MessageEntit
 Parameters:
 - markdown (str): Raw Markdown text.
 - latex_escape (bool, default True): Convert LaTeX \(...\) and \[...\] to Unicode symbols.
-- config (RenderConfig | None): Custom config; uses global singleton if None.
+- config (RenderConfig | None): Render config; uses the process-global config if None. Use RenderConfig.isolated() for per-request symbols.
 
 Returns (text, entities):
 - text (str): Plain text with formatting removed.
 - entities (list[MessageEntity]): Telegram MessageEntity objects with UTF-16 offsets.
 
-### telegramify(content, *, max_message_length=4096, latex_escape=True) -> list[Text | File | Photo]
+### telegramify(content, *, max_message_length=4096, latex_escape=True, config=None) -> list[Text | File | Photo]
 
 Async. Full pipeline: converts Markdown, splits long messages, extracts code blocks as File
 objects, renders Mermaid diagrams as Photo objects.
@@ -150,6 +171,7 @@ Parameters:
 - content (str): Raw Markdown text.
 - max_message_length (int, default 4096): Maximum UTF-16 code units per text message.
 - latex_escape (bool, default True): Convert LaTeX to Unicode.
+- config (RenderConfig | None): Render config; also supplies Mermaid theme/width/scale/type.
 
 Returns an ordered list of Text, File, or Photo objects preserving the original document order.
 

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@ Key design decisions:
 - [Async pipeline — pipeline.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/pipeline.py): Message splitting, code block extraction, Mermaid rendering
 - [Streaming — stream/](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/stream/__init__.py): `DraftStream` (private chat drafts), `EditStream` (group edit fallback), `StreamCore` (generic throttled buffer)
 - [Output types — content.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/content.py): Text, File, Photo, ContentType, ContentTrace
-- [Configuration — config.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/config.py): Symbol customization, RenderConfig singleton
+- [Configuration — config.py](https://raw.githubusercontent.com/sudoskys/telegramify-markdown/main/src/telegramify_markdown/config.py): Symbol customization, global vs isolated RenderConfig
 
 ## Optional
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegramify-markdown"
-version = "1.2.0"
+version = "1.3.0"
 description = "Convert Markdown to Telegram plain text + MessageEntity pairs"
 authors = [
     { name = "sudoskys", email = "coldlando@hotmail.com" },

--- a/src/telegramify_markdown/__init__.py
+++ b/src/telegramify_markdown/__init__.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Union
 
 from telegramify_markdown import config
+from telegramify_markdown.config import RenderConfig
 from telegramify_markdown.converter import convert as convert
 from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
 from telegramify_markdown.content import ContentType, ContentTypes, ContentTrace, File, Photo, RichMessage, Text
@@ -23,6 +24,7 @@ __all__ = [
     "split_rich",
     "telegramify_rich",
     "config",
+    "RenderConfig",
     "MessageEntity",
     "InputRichMessage",
     "RichMessage",
@@ -43,6 +45,7 @@ def markdownify(
     max_line_length: int | None = None,
     normalize_whitespace: bool = False,
     latex_escape: bool = True,
+    config: RenderConfig | None = None,
 ) -> str:
     """Convert Markdown to a Telegram MarkdownV2 string.
 
@@ -51,6 +54,7 @@ def markdownify(
 
     :param max_line_length: Deprecated (ignored). Kept for 0.x compatibility.
     :param normalize_whitespace: Deprecated (ignored). Kept for 0.x compatibility.
+    :param config: Render configuration. Uses the global config if None.
     """
     if max_line_length is not None:
         warnings.warn(
@@ -66,7 +70,7 @@ def markdownify(
             DeprecationWarning,
             stacklevel=2,
         )
-    return entities_to_markdownv2(*convert(content, latex_escape=latex_escape))
+    return entities_to_markdownv2(*convert(content, latex_escape=latex_escape, config=config))
 
 
 def standardize(
@@ -75,6 +79,7 @@ def standardize(
     max_line_length: int | None = None,
     normalize_whitespace: bool = False,
     latex_escape: bool = True,
+    config: RenderConfig | None = None,
 ) -> str:
     """Alias for :func:`markdownify`, kept for 0.x compatibility."""
     return markdownify(
@@ -82,6 +87,7 @@ def standardize(
         max_line_length=max_line_length,
         normalize_whitespace=normalize_whitespace,
         latex_escape=latex_escape,
+        config=config,
     )
 
 
@@ -95,6 +101,7 @@ async def telegramify(
     latex_escape: bool = True,
     render_mermaid: bool = True,
     min_file_lines: int = 1,
+    config: RenderConfig | None = None,
 ) -> list[Union[Text, File, Photo]]:
     """Convert markdown to Telegram-ready content segments.
 
@@ -110,6 +117,9 @@ async def telegramify(
     :param min_file_lines: Minimum line count for a code block to be extracted
         as a separate file.  Set to ``0`` to disable file extraction entirely
         (all code blocks stay inline as ``pre`` entities).
+    :param config: Render configuration. Uses the global config if None.
+        Pass ``RenderConfig.isolated()`` to keep concurrent requests from
+        sharing symbol settings.
     :return: Ordered list of Text, File, or Photo objects ready for the Telegram Bot API.
     """
     if max_word_count is not None:
@@ -119,6 +129,7 @@ async def telegramify(
             DeprecationWarning,
             stacklevel=2,
         )
+        max_message_length = max_word_count
     if max_line_length is not None:
         warnings.warn(
             "max_line_length is deprecated and ignored in 1.x. "
@@ -133,7 +144,6 @@ async def telegramify(
             DeprecationWarning,
             stacklevel=2,
         )
-        max_message_length = max_word_count
 
     from telegramify_markdown.pipeline import process_markdown
 
@@ -143,4 +153,5 @@ async def telegramify(
         latex_escape=latex_escape,
         render_mermaid=render_mermaid,
         min_file_lines=min_file_lines,
+        config=config,
     )

--- a/src/telegramify_markdown/config.py
+++ b/src/telegramify_markdown/config.py
@@ -1,13 +1,20 @@
-def singleton(cls):
-    """Singleton pattern decorator"""
-    instances = {}
-    
-    def get_instance(*args, **kwargs):
-        if cls not in instances:
-            instances[cls] = cls(*args, **kwargs)
-        return instances[cls]
-    
-    return get_instance
+"""Render configuration.
+
+``get_runtime_config()`` returns the process-global config; setting it once at
+startup is the common case. When rendering must vary per session or per thread,
+take an independent config with ``RenderConfig.isolated()`` and pass it to
+``convert(config=...)`` / ``telegramify(config=...)`` / ``markdownify(config=...)``.
+
+The global instance is shared mutable state: writing to it inside a handler is
+visible to every concurrent conversion that does not carry its own config.
+pyTelegramBotAPI runs handlers on multiple threads by default, and on the
+asyncio side "mutate global -> await -> render" always yields control in
+between. Per-request configuration requires isolated().
+"""
+
+from __future__ import annotations
+
+import copy
 
 
 class Symbol:
@@ -23,6 +30,11 @@ class Symbol:
         self.task_completed: str = "\N{WHITE HEAVY CHECK MARK}"  # ✅
         self.task_uncompleted: str = "\N{BALLOT BOX WITH CHECK}" # ☑️
         self.horizontal_rule: str = "————————"
+        # List markers: written after the indent, before the item text.
+        # Always plain text, never covered by an entity.
+        # @see https://github.com/sudoskys/telegramify-markdown/issues/116
+        self.unordered_list_item: str = "\N{Z NOTATION SPOT}"    # ⦁
+        self.ordered_list_suffix: str = "."
 
 
 class Mermaid:
@@ -33,12 +45,43 @@ class Mermaid:
         self.image_type: str = "webp"
 
 
-@singleton
 class RenderConfig:
-    def __init__(self):
+    """Render configuration.
+
+    Bare construction returns the global instance, equivalent to
+    ``get_runtime_config()`` and matching 1.x behaviour. For configs that do not
+    affect each other, use :meth:`isolated`.
+    """
+
+    _global: "RenderConfig | None" = None
+
+    def __new__(cls) -> "RenderConfig":
+        if cls._global is None:
+            cls._global = super().__new__(cls)
+            cls._global._init_defaults()
+        return cls._global
+
+    # No __init__ on purpose: repeated construction must not reset settings
+    # that have already been applied to the global instance.
+    def _init_defaults(self) -> None:
         self._markdown_symbol = Symbol()
         self._mermaid = Mermaid()
         self._cite_expandable = True
+
+    @classmethod
+    def isolated(cls) -> "RenderConfig":
+        """Build an independent config, sharing nothing with the global one."""
+        instance = super().__new__(cls)
+        instance._init_defaults()
+        return instance
+
+    def copy(self) -> "RenderConfig":
+        """Copy this config into an independent one, symbol tables included."""
+        instance = super().__new__(type(self))
+        instance._markdown_symbol = copy.deepcopy(self._markdown_symbol)
+        instance._mermaid = copy.deepcopy(self._mermaid)
+        instance._cite_expandable = self._cite_expandable
+        return instance
 
     @property
     def markdown_symbol(self) -> Symbol:

--- a/src/telegramify_markdown/converter.py
+++ b/src/telegramify_markdown/converter.py
@@ -26,100 +26,71 @@ STANDARD_OPTIONS = (
 # --- Preprocessing -----------------------------------------------------------
 
 _SPOILER_RE = re.compile(r"(?<![\\])\|\|(.+?)\|\|", re.DOTALL)
-_INLINE_CODE_RE = re.compile(r"(`[^`\n]+`)")
-_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
-_LIST_MARKER_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
-_INDENTED_RE = re.compile(r"^(?: {4}|\t)")
 
 
-def _code_line_flags(text: str) -> list[bool]:
-    """Mark each line that belongs to a code block, so spoilers skip it.
+def _code_regions(text: str, options) -> list[tuple[int, int]]:
+    """UTF-8 byte ranges of the source that the parser treats as code.
 
-    This is not a full CommonMark block parse; it covers only the two shapes
-    that would otherwise corrupt user code:
-
-    - Fenced code: both ``` and ~~~ count. A closing fence must use the same
-      character and be no shorter than the opening one; an unclosed fence runs
-      to end of input, as CommonMark specifies. A single regex cannot express
-      that pairing, hence the line scan.
-    - Indented code: only when the previous line is blank and no list is open.
-      Without those two guards this misfires on two common shapes -- indented
-      paragraph continuations, and nested list items indented four spaces or
-      more -- which would silently drop ||spoiler|| at those positions.
+    Asking pyromark rather than scanning lines. A hand-rolled scanner has to
+    reimplement CommonMark's container prefixes to get this right: a fence can
+    sit inside a blockquote or a list item, a backtick fence's info string may
+    not contain a backtick, and indented code has its own rules about what
+    precedes it. Each of those was got wrong in turn, and getting it wrong
+    rewrites the user's code instead of a spoiler.
     """
-    lines = text.split("\n")
-    flags = [False] * len(lines)
-    fence: str | None = None
-    list_open = False
-    prev_blank = True
-
-    for i, line in enumerate(lines):
-        if fence is not None:
-            flags[i] = True
-            closing = _FENCE_RE.match(line)
-            if closing and closing.group(1)[0] == fence[0] and len(closing.group(1)) >= len(fence):
-                fence = None
+    regions: list[tuple[int, int]] = []
+    for event in pyromark.events_with_range(text, options=options):
+        if not (
+            isinstance(event, tuple)
+            and len(event) == 2
+            and isinstance(event[1], dict)
+        ):
             continue
-
-        opening = _FENCE_RE.match(line)
-        if opening:
-            fence = opening.group(1)
-            flags[i] = True
-            prev_blank = False
+        payload, source_range = event
+        if not isinstance(payload, dict):
             continue
+        start = payload.get("Start")
+        is_code_block = isinstance(start, dict) and "CodeBlock" in start
+        if is_code_block or "Code" in payload:
+            regions.append((source_range["start"], source_range["end"]))
 
-        blank = not line.strip()
-        if blank:
-            prev_blank = True
-            continue
-
-        if _LIST_MARKER_RE.match(line):
-            list_open = True
-        elif not _INDENTED_RE.match(line) and not line.startswith((" ", "\t")):
-            list_open = False
-
-        if _INDENTED_RE.match(line) and prev_blank and not list_open:
-            flags[i] = True
-        prev_blank = False
-
-    return flags
+    regions.sort()
+    merged: list[tuple[int, int]] = []
+    for region_start, region_end in regions:
+        if merged and region_start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], region_end))
+        else:
+            merged.append((region_start, region_end))
+    return merged
 
 
-def _preprocess_spoilers(text: str) -> str:
+def _preprocess_spoilers(text: str, options=STANDARD_OPTIONS) -> str:
     """Replace ||spoiler|| with <tg-spoiler>spoiler</tg-spoiler>.
 
-    Skips content inside fenced code (``` and ~~~), indented code blocks,
-    and inline code spans.
+    Content inside fenced code, indented code, and inline code spans is left
+    alone. Documents without ``||`` skip the extra parse entirely.
+
+    ``options`` must match the ones the caller will parse the result with:
+    enabling footnotes, for instance, makes an indented block under a footnote
+    definition part of the footnote rather than an indented code block.
     """
-    code_line = _code_line_flags(text)
-    lines = text.split("\n")
+    if "||" not in text:
+        return text
 
-    # Group into runs of code / non-code lines: a spoiler may span lines, so
-    # substitution runs over a whole segment rather than line by line.
-    runs: list[str] = []
-    current: list[str] = []
-    current_is_code = False
-
-    def close_run() -> None:
-        joined = "\n".join(current)
-        runs.append(joined if current_is_code else _substitute_spoilers(joined))
-        current.clear()
-
-    for line, is_code in zip(lines, code_line):
-        if current and is_code != current_is_code:
-            close_run()
-        current_is_code = is_code
-        current.append(line)
-    if current:
-        close_run()
-    return "\n".join(runs)
-
-
-def _substitute_spoilers(segment: str) -> str:
-    """Replace ||...|| inside a non-code segment, still skipping code spans."""
-    parts = _INLINE_CODE_RE.split(segment)
-    for i in range(0, len(parts), 2):
-        parts[i] = _SPOILER_RE.sub(_spoiler_replacement, parts[i])
+    data = text.encode("utf-8")
+    parts: list[str] = []
+    cursor = 0
+    for region_start, region_end in _code_regions(text, options):
+        parts.append(
+            _SPOILER_RE.sub(
+                _spoiler_replacement, data[cursor:region_start].decode("utf-8")
+            )
+        )
+        parts.append(data[region_start:region_end].decode("utf-8"))
+        cursor = region_end
+    parts.append(
+        _SPOILER_RE.sub(_spoiler_replacement, data[cursor:].decode("utf-8"))
+    )
     return "".join(parts)
 
 
@@ -134,11 +105,14 @@ def _spoiler_replacement(match: re.Match) -> str:
     line as the text, so this stays inline HTML.
     """
     content = match.group(1)
-    stripped = content.strip("\n")
+    stripped = content.strip("\r\n")
     if not stripped:
         return match.group(0)
-    leading = "\n" * (len(content) - len(content.lstrip("\n")))
-    trailing = "\n" * (len(content) - len(content.rstrip("\n")))
+    # Move the exact line breaks back outside, CR included: stripping only "\n"
+    # leaves a leading "\r" behind, which still puts the open tag on its own
+    # line under CRLF input and loses the whole span.
+    leading = content[: len(content) - len(content.lstrip("\r\n"))]
+    trailing = content[len(content.rstrip("\r\n")) :]
     return f"{leading}<tg-spoiler>{stripped}</tg-spoiler>{trailing}"
 
 
@@ -842,14 +816,22 @@ class EventWalker:
         newlines = 0
         while i >= 0:
             ch = self._source_bytes[i : i + 1]
-            if ch == b"\n":
+            if ch == b"\r":
+                # CommonMark accepts a bare CR as a line ending. Inside a CRLF
+                # the LF already counted, so only a lone CR adds one.
+                if self._source_bytes[i + 1 : i + 2] == b"\n":
+                    i -= 1
+                    continue
                 newlines += 1
-                if newlines >= 2:
-                    return True
-            elif ch in (b"\r", b" ", b"\t", b">"):
-                pass
+            elif ch == b"\n":
+                newlines += 1
+            elif ch in (b" ", b"\t", b">"):
+                i -= 1
+                continue
             else:
                 return False
+            if newlines >= 2:
+                return True
             i -= 1
         return False
 

--- a/src/telegramify_markdown/converter.py
+++ b/src/telegramify_markdown/converter.py
@@ -26,21 +26,120 @@ STANDARD_OPTIONS = (
 # --- Preprocessing -----------------------------------------------------------
 
 _SPOILER_RE = re.compile(r"(?<![\\])\|\|(.+?)\|\|", re.DOTALL)
-_CODE_REGION_RE = re.compile(r"(```[\s\S]*?```|`[^`\n]+`)")
+_INLINE_CODE_RE = re.compile(r"(`[^`\n]+`)")
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+_LIST_MARKER_RE = re.compile(r"^ {0,3}(?:[-*+]|\d{1,9}[.)])(?:[ \t]|$)")
+_INDENTED_RE = re.compile(r"^(?: {4}|\t)")
+
+
+def _code_line_flags(text: str) -> list[bool]:
+    """Mark each line that belongs to a code block, so spoilers skip it.
+
+    This is not a full CommonMark block parse; it covers only the two shapes
+    that would otherwise corrupt user code:
+
+    - Fenced code: both ``` and ~~~ count. A closing fence must use the same
+      character and be no shorter than the opening one; an unclosed fence runs
+      to end of input, as CommonMark specifies. A single regex cannot express
+      that pairing, hence the line scan.
+    - Indented code: only when the previous line is blank and no list is open.
+      Without those two guards this misfires on two common shapes -- indented
+      paragraph continuations, and nested list items indented four spaces or
+      more -- which would silently drop ||spoiler|| at those positions.
+    """
+    lines = text.split("\n")
+    flags = [False] * len(lines)
+    fence: str | None = None
+    list_open = False
+    prev_blank = True
+
+    for i, line in enumerate(lines):
+        if fence is not None:
+            flags[i] = True
+            closing = _FENCE_RE.match(line)
+            if closing and closing.group(1)[0] == fence[0] and len(closing.group(1)) >= len(fence):
+                fence = None
+            continue
+
+        opening = _FENCE_RE.match(line)
+        if opening:
+            fence = opening.group(1)
+            flags[i] = True
+            prev_blank = False
+            continue
+
+        blank = not line.strip()
+        if blank:
+            prev_blank = True
+            continue
+
+        if _LIST_MARKER_RE.match(line):
+            list_open = True
+        elif not _INDENTED_RE.match(line) and not line.startswith((" ", "\t")):
+            list_open = False
+
+        if _INDENTED_RE.match(line) and prev_blank and not list_open:
+            flags[i] = True
+        prev_blank = False
+
+    return flags
 
 
 def _preprocess_spoilers(text: str) -> str:
     """Replace ||spoiler|| with <tg-spoiler>spoiler</tg-spoiler>.
 
-    Skips content inside code fences and inline code spans.
+    Skips content inside fenced code (``` and ~~~), indented code blocks,
+    and inline code spans.
     """
-    parts = _CODE_REGION_RE.split(text)
-    result: list[str] = []
-    for i, part in enumerate(parts):
-        if i % 2 == 0:  # Not inside code
-            part = _SPOILER_RE.sub(r"<tg-spoiler>\1</tg-spoiler>", part)
-        result.append(part)
-    return "".join(result)
+    code_line = _code_line_flags(text)
+    lines = text.split("\n")
+
+    # Group into runs of code / non-code lines: a spoiler may span lines, so
+    # substitution runs over a whole segment rather than line by line.
+    runs: list[str] = []
+    current: list[str] = []
+    current_is_code = False
+
+    def close_run() -> None:
+        joined = "\n".join(current)
+        runs.append(joined if current_is_code else _substitute_spoilers(joined))
+        current.clear()
+
+    for line, is_code in zip(lines, code_line):
+        if current and is_code != current_is_code:
+            close_run()
+        current_is_code = is_code
+        current.append(line)
+    if current:
+        close_run()
+    return "\n".join(runs)
+
+
+def _substitute_spoilers(segment: str) -> str:
+    """Replace ||...|| inside a non-code segment, still skipping code spans."""
+    parts = _INLINE_CODE_RE.split(segment)
+    for i in range(0, len(parts), 2):
+        parts[i] = _SPOILER_RE.sub(_spoiler_replacement, parts[i])
+    return "".join(parts)
+
+
+def _spoiler_replacement(match: re.Match) -> str:
+    """Wrap ||...|| in <tg-spoiler>, keeping the open tag off its own line.
+
+    CommonMark treats a line holding nothing but a complete open tag as an HTML
+    block (type 7). A literal translation of ``||\\ncontent\\n||`` puts
+    ``<tg-spoiler>`` alone on a line, so the whole thing parses as an HTML block
+    -- and the converter drops Html events, silently losing the content. Moving
+    the leading and trailing newlines outside the tags keeps them on the same
+    line as the text, so this stays inline HTML.
+    """
+    content = match.group(1)
+    stripped = content.strip("\n")
+    if not stripped:
+        return match.group(0)
+    leading = "\n" * (len(content) - len(content.lstrip("\n")))
+    trailing = "\n" * (len(content) - len(content.rstrip("\n")))
+    return f"{leading}<tg-spoiler>{stripped}</tg-spoiler>{trailing}"
 
 
 def _validate_telegram_emoji(url: str) -> Optional[str]:
@@ -57,16 +156,21 @@ _LATEX_MATH_P = re.compile(r"\\\[(.*?)\\\]", re.DOTALL)
 _LATEX_INLINE_P = re.compile(r"\\\((.*?)\\\)", re.DOTALL)
 
 
+# Common LaTeX commands plus the full symbol tables, used to decide whether a
+# fragment is worth running through LaTeX conversion. Built once at module level:
+# the table has 500+ entries and rebuilding it per call is pure waste.
+_LATEX_PROBE_SYMBOLS = (
+    (r"\frac", r"\sqrt", r"\begin")
+    + tuple(LATEX_SYMBOLS.keys())
+    + tuple(NOT_MAP.keys())
+    + tuple(LATEX_STYLES.keys())
+)
+
+
 def _contains_latex_symbols(content: str) -> bool:
     if len(content) < 5:
         return False
-    latex_symbols = (
-        (r"\frac", r"\sqrt", r"\begin")
-        + tuple(LATEX_SYMBOLS.keys())
-        + tuple(NOT_MAP.keys())
-        + tuple(LATEX_STYLES.keys())
-    )
-    return any(symbol in content for symbol in latex_symbols)
+    return any(symbol in content for symbol in _LATEX_PROBE_SYMBOLS)
 
 
 def _escape_latex(text: str) -> str:
@@ -113,15 +217,17 @@ class Segment:
 class _TextBuffer:
     """Accumulates plain text and tracks the current UTF-16 offset."""
 
-    __slots__ = ("_parts", "_utf16_offset")
+    __slots__ = ("_parts", "_utf16_offset", "_py_offset")
 
     def __init__(self) -> None:
         self._parts: list[str] = []
         self._utf16_offset: int = 0
+        self._py_offset: int = 0
 
     def write(self, text: str) -> None:
         self._parts.append(text)
         self._utf16_offset += utf16_len(text)
+        self._py_offset += len(text)
 
     @property
     def utf16_offset(self) -> int:
@@ -129,7 +235,10 @@ class _TextBuffer:
 
     @property
     def py_offset(self) -> int:
-        return sum(len(p) for p in self._parts)
+        # Tracked incrementally instead of recomputing sum(len(p) for p in _parts):
+        # _on_start_item reads this for every list item, so recomputing degrades
+        # conversion to O(n^2) -- a 4000-item document took 400ms.
+        return self._py_offset
 
     def trailing_newline_count(self) -> int:
         """Count trailing newline characters in the buffer."""
@@ -143,10 +252,11 @@ class _TextBuffer:
         return count
 
     def pop_last(self) -> str:
-        """移除并返回最后写入的部分。用于替换刚写入的 bullet 前缀。"""
+        """Remove and return the last written part, to replace a bullet prefix."""
         if self._parts:
             part = self._parts.pop()
             self._utf16_offset -= utf16_len(part)
+            self._py_offset -= len(part)
             return part
         return ""
 
@@ -184,14 +294,10 @@ class EventWalker:
 
         # Block-level state
         self._block_count: int = 0  # For paragraph spacing
-        self._last_block_end_source: int | None = None
         self._list_stack: list[int | None] = []  # None=unordered, int=next_number
-        self._item_started: bool = False
         self._item_indent: str = ""  # 当前 item 的缩进，用于 task list marker 替换
 
         # Table state
-        self._in_table: bool = False
-        self._table_alignments: tuple = ()
         self._table_rows: list[list[str]] = []
         self._current_row: list[str] = []
         self._cell_parts: list[str] = []
@@ -204,7 +310,6 @@ class EventWalker:
         self._code_block_start_source: int | None = None
 
         # Heading state
-        self._in_heading: bool = False
         self._heading_entities: list[str] = []
 
         # Blockquote state
@@ -247,7 +352,7 @@ class EventWalker:
         if "Start" in event:
             self._on_start(event["Start"], source_range)
         elif "End" in event:
-            self._on_end(event["End"], source_range)
+            self._on_end(event["End"])
         elif "Text" in event:
             self._on_text(event["Text"])
         elif "Code" in event:
@@ -302,14 +407,13 @@ class EventWalker:
             elif "List" in tag:
                 self._on_start_list(tag["List"], source_start)
             elif "Table" in tag:
-                self._on_start_table(tag["Table"], source_start)
+                self._on_start_table(source_start)
             elif "FootnoteDefinition" in tag:
                 self._ensure_block_spacing(source_start)
 
     # -- End events ------------------------------------------------------------
 
-    def _on_end(self, tag, source_range: dict[str, int] | None = None) -> None:
-        source_end = self._source_end(source_range)
+    def _on_end(self, tag) -> None:
         if tag == "Strong":
             self._pop_entity("bold")
         elif tag == "Emphasis":
@@ -317,13 +421,13 @@ class EventWalker:
         elif tag == "Strikethrough":
             self._pop_entity("strikethrough")
         elif tag == "Paragraph":
-            self._on_end_paragraph(source_end)
+            self._on_end_paragraph()
         elif tag == "Item":
             self._on_end_item()
         elif tag == "CodeBlock":
-            self._on_end_code_block(source_end)
+            self._on_end_code_block()
         elif tag == "Table":
-            self._on_end_table(source_end)
+            self._on_end_table()
         elif tag == "TableCell":
             self._on_end_table_cell()
         elif tag == "TableRow":
@@ -338,11 +442,11 @@ class EventWalker:
             pass
         elif isinstance(tag, dict):
             if "Heading" in tag:
-                self._on_end_heading(source_end)
+                self._on_end_heading()
             elif "BlockQuote" in tag:
-                self._on_end_blockquote(source_end)
+                self._on_end_blockquote()
             elif "List" in tag:
-                self._on_end_list(source_end)
+                self._on_end_list()
 
     # -- Inline events ---------------------------------------------------------
 
@@ -373,7 +477,7 @@ class EventWalker:
     def _on_rule(self, source_range: dict[str, int] | None = None) -> None:
         self._ensure_block_spacing(self._source_start(source_range))
         self._buf.write(self._config.markdown_symbol.horizontal_rule)
-        self._mark_block_end(self._source_end(source_range))
+        self._mark_block_end()
 
     def _on_inline_code(self, code: str) -> None:
         if self._in_table_cell:
@@ -405,7 +509,7 @@ class EventWalker:
         length = self._buf.utf16_offset - start
         if length > 0:
             self._entities.append(MessageEntity(type="pre", offset=start, length=length))
-        self._mark_block_end(self._source_end(source_range))
+        self._mark_block_end()
 
     def _on_inline_html(self, html: str) -> None:
         tag = html.strip().lower()
@@ -456,14 +560,12 @@ class EventWalker:
         self._heading_entities = self._HEADING_ENTITIES.get(level, ["bold"])
         for etype in self._heading_entities:
             self._push_entity(etype)
-        self._in_heading = True
 
-    def _on_end_heading(self, source_end: int | None = None) -> None:
+    def _on_end_heading(self) -> None:
         for etype in reversed(self._heading_entities):
             self._pop_entity(etype)
         self._heading_entities = []
-        self._in_heading = False
-        self._mark_block_end(source_end)
+        self._mark_block_end()
 
     # -- Paragraph -------------------------------------------------------------
 
@@ -471,9 +573,9 @@ class EventWalker:
         if not self._list_stack:
             self._ensure_block_spacing(source_start)
 
-    def _on_end_paragraph(self, source_end: int | None = None) -> None:
+    def _on_end_paragraph(self) -> None:
         if not self._list_stack:
-            self._mark_block_end(source_end)
+            self._mark_block_end()
         elif self._buf.trailing_newline_count() == 0:
             # loose list 中段落结束时写入换行，避免多段落粘连
             self._buf.write("\n")
@@ -489,7 +591,7 @@ class EventWalker:
         else:
             self._code_block_lang = ""
 
-    def _on_end_code_block(self, source_end: int | None = None) -> None:
+    def _on_end_code_block(self) -> None:
         self._in_code_block = False
         raw_code = "".join(self._code_block_parts)
         # Strip single trailing newline (pulldown-cmark adds one)
@@ -531,7 +633,7 @@ class EventWalker:
             )
         )
 
-        self._mark_block_end(source_end)
+        self._mark_block_end()
         self._code_block_lang = ""
         self._code_block_parts = []
         self._code_block_start_source = None
@@ -543,7 +645,7 @@ class EventWalker:
         scope = _EntityScope("blockquote", self._buf.utf16_offset)
         self._blockquote_scopes.append(scope)
 
-    def _on_end_blockquote(self, source_end: int | None = None) -> None:
+    def _on_end_blockquote(self) -> None:
         if self._blockquote_scopes:
             scope = self._blockquote_scopes.pop()
             length = self._buf.utf16_offset - scope.start_offset
@@ -555,7 +657,7 @@ class EventWalker:
                         length=length,
                     )
                 )
-        self._mark_block_end(source_end)
+        self._mark_block_end()
 
     # -- Links -----------------------------------------------------------------
 
@@ -576,7 +678,13 @@ class EventWalker:
         if emoji_id:
             self._push_entity("custom_emoji", custom_emoji_id=emoji_id)
         else:
-            self._buf.write(self._config.markdown_symbol.image)
+            # Route through _on_text rather than writing _buf directly: inside a
+            # table cell the image symbol must land in _cell_parts, otherwise it
+            # leaks out ahead of the rendered table and skews the column widths.
+            self._on_text(self._config.markdown_symbol.image)
+            # Inside a cell _buf does not advance, so the entity ends up
+            # zero-length and _finalize_entity drops it. Still push it: without
+            # it End(Image)'s _pop_entity_any would close an outer scope.
             self._push_entity("text_link", url=dest_url)
 
     # -- Lists -----------------------------------------------------------------
@@ -600,30 +708,29 @@ class EventWalker:
         self._item_indent = indent
         if current_list is not None:
             # Ordered list
-            self._buf.write(f"{indent}{current_list}. ")
+            suffix = self._config.markdown_symbol.ordered_list_suffix
+            self._buf.write(f"{indent}{current_list}{suffix} ")
             self._list_stack[-1] = current_list + 1
         else:
             # Unordered list
-            self._buf.write(f"{indent}⦁ ")
-        self._item_started = True
+            marker = self._config.markdown_symbol.unordered_list_item
+            self._buf.write(f"{indent}{marker} ")
 
     def _on_end_item(self) -> None:
         if self._buf.trailing_newline_count() == 0:
             self._buf.write("\n")
-        self._item_started = False
 
-    def _on_end_list(self, source_end: int | None = None) -> None:
+    def _on_end_list(self) -> None:
         if self._list_stack:
             self._list_stack.pop()
         if not self._list_stack:
-            self._mark_block_end(source_end)
+            self._mark_block_end()
 
     # -- Tables ----------------------------------------------------------------
 
-    def _on_start_table(self, alignments, source_start: int | None = None) -> None:
+    def _on_start_table(self, source_start: int | None = None) -> None:
+        # The text table renders as fixed-width columns and ignores alignment
         self._ensure_block_spacing(source_start)
-        self._in_table = True
-        self._table_alignments = alignments if isinstance(alignments, tuple) else ()
         self._table_rows = []
 
     def _on_end_table_cell(self) -> None:
@@ -635,8 +742,7 @@ class EventWalker:
         self._table_rows.append(self._current_row)
         self._current_row = []
 
-    def _on_end_table(self, source_end: int | None = None) -> None:
-        self._in_table = False
+    def _on_end_table(self) -> None:
         table_text = self._format_table(self._table_rows)
 
         start = self._buf.utf16_offset
@@ -645,7 +751,7 @@ class EventWalker:
         if length > 0:
             self._entities.append(MessageEntity(type="pre", offset=start, length=length))
         self._table_rows = []
-        self._mark_block_end(source_end)
+        self._mark_block_end()
 
     def _format_table(self, rows: list[list[str]]) -> str:
         if not rows:
@@ -717,22 +823,35 @@ class EventWalker:
     def _source_start(source_range: dict[str, int] | None) -> int | None:
         return source_range.get("start") if source_range else None
 
-    @staticmethod
-    def _source_end(source_range: dict[str, int] | None) -> int | None:
-        return source_range.get("end") if source_range else None
-
-    def _mark_block_end(self, source_end: int | None = None) -> None:
+    def _mark_block_end(self) -> None:
         self._block_count += 1
-        if source_end is not None:
-            self._last_block_end_source = source_end
 
     def _has_extra_blank_line(self, next_block_start: int) -> bool:
-        if self._last_block_end_source is None:
-            return False
-        if next_block_start <= self._last_block_end_source:
-            return False
-        gap = self._source_bytes[self._last_block_end_source:next_block_start]
-        return b"\n" in gap or b"\r" in gap
+        """Whether the source holds a blank line just before next_block_start.
+
+        The gap between the previous block's source end and this block's start
+        cannot answer this: pyromark's List range already swallows the trailing
+        blank line (for ``- a\\n- b\\n\\npara`` the End(List) range is 0..9 while
+        para starts at 9, leaving an empty gap), so every block after a list
+        lost its blank line. Scanning backwards from next_block_start instead --
+        skipping indentation and blockquote ``>`` markers while counting
+        newlines -- answers the question directly, independent of where the
+        previous block was said to end.
+        """
+        i = next_block_start - 1
+        newlines = 0
+        while i >= 0:
+            ch = self._source_bytes[i : i + 1]
+            if ch == b"\n":
+                newlines += 1
+                if newlines >= 2:
+                    return True
+            elif ch in (b"\r", b" ", b"\t", b">"):
+                pass
+            else:
+                return False
+            i -= 1
+        return False
 
     def _ensure_block_spacing(self, next_block_start: int | None = None) -> None:
         """Ensure block spacing, preserving whether the source had an extra blank line."""

--- a/src/telegramify_markdown/entity.py
+++ b/src/telegramify_markdown/entity.py
@@ -14,10 +14,12 @@ def utf16_len(text: str) -> int:
     # ASCII is the common case, and str.isascii() is a flag check in CPython (O(1)).
     # Non-ASCII goes through a C-level encode, 25-100x faster than a per-character
     # ord() loop. _TextBuffer.write calls this on every write, so it sits on the
-    # hot path of conversion.
+    # hot path of conversion. surrogatepass keeps lone surrogates working: a
+    # plain encode raises on them, while counting them is well defined (one
+    # code unit each) and callers may hold them from surrogateescape decoding.
     if text.isascii():
         return len(text)
-    return len(text.encode("utf-16-le")) >> 1
+    return len(text.encode("utf-16-le", "surrogatepass")) >> 1
 
 
 @dataclasses.dataclass(slots=True)

--- a/src/telegramify_markdown/entity.py
+++ b/src/telegramify_markdown/entity.py
@@ -11,10 +11,13 @@ def utf16_len(text: str) -> int:
     not Python str characters. Characters outside the BMP (codepoint > 0xFFFF)
     take 2 UTF-16 code units (a surrogate pair); all others take 1.
     """
-    count = 0
-    for ch in text:
-        count += 2 if ord(ch) > 0xFFFF else 1
-    return count
+    # ASCII is the common case, and str.isascii() is a flag check in CPython (O(1)).
+    # Non-ASCII goes through a C-level encode, 25-100x faster than a per-character
+    # ord() loop. _TextBuffer.write calls this on every write, so it sits on the
+    # hot path of conversion.
+    if text.isascii():
+        return len(text)
+    return len(text.encode("utf-16-le")) >> 1
 
 
 @dataclasses.dataclass(slots=True)

--- a/src/telegramify_markdown/mdv2.py
+++ b/src/telegramify_markdown/mdv2.py
@@ -12,46 +12,44 @@
 
 from __future__ import annotations
 
+from bisect import bisect_right
+
 from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
 
 # MarkdownV2 普通文本需要转义的 20 个字符
-_MDV2_ESCAPE_CHARS = frozenset("_*[]()~`>#+-=|{}.!\\")
+_MDV2_ESCAPE_CHARS = "_*[]()~`>#+-=|{}.!\\"
 
 # code/pre 内只需转义的字符
-_CODE_ESCAPE_CHARS = frozenset("`\\")
+_CODE_ESCAPE_CHARS = "`\\"
 
 # URL 内只需转义的字符
-_URL_ESCAPE_CHARS = frozenset(")\\")
+_URL_ESCAPE_CHARS = ")\\"
+
+
+def _escape_table(chars: str) -> dict[int, str]:
+    return str.maketrans({ch: "\\" + ch for ch in chars})
+
+
+# A translation table runs in one C-level pass, 1.4-3.4x faster than appending
+# per character. Escaping is on the path of every text segment.
+_MDV2_TRANS = _escape_table(_MDV2_ESCAPE_CHARS)
+_CODE_TRANS = _escape_table(_CODE_ESCAPE_CHARS)
+_URL_TRANS = _escape_table(_URL_ESCAPE_CHARS)
 
 
 def _escape_markdownv2(text: str) -> str:
     """普通文本区域的 MarkdownV2 转义（20 个特殊字符）。"""
-    result = []
-    for ch in text:
-        if ch in _MDV2_ESCAPE_CHARS:
-            result.append("\\")
-        result.append(ch)
-    return "".join(result)
+    return text.translate(_MDV2_TRANS)
 
 
 def _escape_code(text: str) -> str:
     """code/pre 内部的转义（只转义 ` 和 \\）。"""
-    result = []
-    for ch in text:
-        if ch in _CODE_ESCAPE_CHARS:
-            result.append("\\")
-        result.append(ch)
-    return "".join(result)
+    return text.translate(_CODE_TRANS)
 
 
 def _escape_url(url: str) -> str:
     """URL 内部的转义（只转义 ) 和 \\）。"""
-    result = []
-    for ch in url:
-        if ch in _URL_ESCAPE_CHARS:
-            result.append("\\")
-        result.append(ch)
-    return "".join(result)
+    return url.translate(_URL_TRANS)
 
 
 def _utf16_offset_to_pyindex(text: str) -> dict[int, int]:
@@ -108,29 +106,31 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
         else:
             other_entities.append(ent)
 
-    # blockquote 查询辅助函数
-    def _bq_at(py_idx: int) -> str | None:
-        """返回 py_idx 位置的 blockquote 类型，不在 blockquote 内返回 None。"""
-        for s, e, t in bq_ranges:
-            if s <= py_idx < e:
-                return t
-        return None
-
-    def _is_expandable_start(py_idx: int) -> bool:
-        for s, _, t in bq_ranges:
-            if py_idx == s and t == "expandable_blockquote":
-                return True
-        return False
-
-    def _is_expandable_end(py_idx: int) -> bool:
-        for _, e, t in bq_ranges:
-            if py_idx == e and t == "expandable_blockquote":
-                return True
-        return False
-
+    # Blockquote position lookup runs once per line, so it must be constant or
+    # logarithmic. Scanning bq_ranges linearly degraded quote-heavy documents to
+    # O(lines x quotes) -- a 43KB all-quote document took 161ms.
+    expandable_starts = {
+        start_py for start_py, _, typ in bq_ranges if typ == "expandable_blockquote"
+    }
     expandable_end_positions = {
         end_py for _, end_py, typ in bq_ranges if typ == "expandable_blockquote"
     }
+
+    sorted_ranges = sorted(bq_ranges)
+    bq_starts = [start_py for start_py, _, _ in sorted_ranges]
+    # Prefix maximum of end positions: the rightmost end among ranges starting
+    # at or before py_idx. If it exceeds py_idx some range covers py_idx --
+    # ranges may nest, so the nearest one alone is not enough.
+    bq_max_end: list[int] = []
+    running_max = 0
+    for _, end_py, _typ in sorted_ranges:
+        running_max = max(running_max, end_py)
+        bq_max_end.append(running_max)
+
+    def _in_bq(py_idx: int) -> bool:
+        """Whether py_idx falls inside any blockquote range."""
+        k = bisect_right(bq_starts, py_idx)
+        return k > 0 and bq_max_end[k - 1] > py_idx
 
     # 构建扫描线事件
     events: list[tuple[int, int, int, int, MessageEntity]] = []
@@ -160,9 +160,9 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
 
     # 输出文本第一行的 blockquote 前缀（如果 position 0 在 blockquote 内）
     if bq_ranges:
-        if _is_expandable_start(0):
+        if 0 in expandable_starts:
             parts.append("**>")
-        elif _bq_at(0) is not None:
+        elif _in_bq(0):
             parts.append(">")
 
     def _emit_segment(segment: str, seg_start_py: int) -> None:
@@ -179,9 +179,9 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
                 parts.append("\n")
                 next_py = seg_start_py + i + 1
                 # 检查下一行的 blockquote 状态
-                if _is_expandable_start(next_py):
+                if next_py in expandable_starts:
                     parts.append("**>")
-                elif _bq_at(next_py) is not None:
+                elif _in_bq(next_py):
                     parts.append(">")
                 line_start = i + 1
         # 输出最后一段（\n 之后的剩余内容）
@@ -210,12 +210,9 @@ def entities_to_markdownv2(text: str, entities: list[MessageEntity] | None = Non
             return
         # tag 中的 \n 后需要检查 blockquote
         # pos_py 是 tag 对应的原始文本边界位置
-        bq = _bq_at(pos_py)
-        if bq is None:
-            # pos_py 可能恰好在 blockquote 边界外，检查 pos_py-1
-            if pos_py > 0:
-                bq = _bq_at(pos_py - 1)
-        if bq:
+        # pos_py may land just outside the blockquote boundary; look one back
+        inside = _in_bq(pos_py) or (pos_py > 0 and _in_bq(pos_py - 1))
+        if inside:
             parts.append(tag.replace("\n", "\n>"))
         else:
             parts.append(tag)

--- a/src/telegramify_markdown/mermaid.py
+++ b/src/telegramify_markdown/mermaid.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import dataclasses
 import json
@@ -110,15 +109,17 @@ def safe_base64_encode(data):
     return base64.urlsafe_b64encode(data)
 
 
-def generate_pako(graph_markdown: str, mermaid_config: MermaidConfig = None) -> str:
+def generate_pako(graph_markdown: str, mermaid_config: MermaidConfig = None, config=None) -> str:
     """
     Generate the pako URL for the Mermaid graph.
     :param graph_markdown: Input Mermaid graph markdown
     :param mermaid_config: Mermaid configuration
+    :param config: RenderConfig; falls back to the global one when omitted
     :return: The pako URL
     """
     if mermaid_config is None:
-        mermaid_config = MermaidConfig(theme=get_runtime_config().mermaid.theme)
+        settings = (config or get_runtime_config()).mermaid
+        mermaid_config = MermaidConfig(theme=settings.theme)
     graph_data = {
         "code": graph_markdown,
         "mermaid": mermaid_config.__dict__
@@ -129,9 +130,9 @@ def generate_pako(graph_markdown: str, mermaid_config: MermaidConfig = None) -> 
     return f"pako:{base64_encoded.decode('ascii')}"
 
 
-def _build_mermaid_ink_query() -> str:
-    """Build Mermaid Ink query parameters from runtime config."""
-    mermaid_config = get_runtime_config().mermaid
+def _build_mermaid_ink_query(config=None) -> str:
+    """Build Mermaid Ink query parameters from the given (or global) config."""
+    mermaid_config = (config or get_runtime_config()).mermaid
     return urlencode(
         {
             "theme": mermaid_config.theme,
@@ -154,33 +155,36 @@ def b64_mermaid_url(diagram: str) -> str:
     return f'https://mermaid.ink/img/{diagram_encoded}?{_build_mermaid_ink_query()}'
 
 
-def get_mermaid_live_url(graph_markdown: str) -> str:
+def get_mermaid_live_url(graph_markdown: str, config=None) -> str:
     """
     Get the Mermaid Live URL for the graph.
     Can be used to edit the graph in the browser.
-    :param graph_markdown:
-    :return:
+    :param graph_markdown: The Mermaid graph Markdown
+    :param config: RenderConfig; falls back to the global one when omitted
+    :return: Link
     """
-    return f'https://mermaid.live/edit/#{generate_pako(graph_markdown)}'
+    return f'https://mermaid.live/edit/#{generate_pako(graph_markdown, config=config)}'
 
 
-def get_mermaid_ink_url(graph_markdown: str) -> str:
+def get_mermaid_ink_url(graph_markdown: str, config=None) -> str:
     """
     Get the Mermaid Ink URL for the graph.
     Can be used to download the image.
     :param graph_markdown: The Mermaid graph Markdown
+    :param config: RenderConfig; falls back to the global one when omitted
     :return: Link
     """
-    return f'https://mermaid.ink/img/{generate_pako(graph_markdown)}?{_build_mermaid_ink_query()}'
+    return f'https://mermaid.ink/img/{generate_pako(graph_markdown, config=config)}?{_build_mermaid_ink_query(config)}'
 
 
 async def render_mermaid(
         diagram: str,
         session: "ClientSession" = None,
+        config=None,
 ) -> Tuple[BytesIO, str]:
     # render picture
-    img_url = get_mermaid_ink_url(diagram)
-    caption = get_mermaid_live_url(diagram)
+    img_url = get_mermaid_ink_url(diagram, config)
+    caption = get_mermaid_live_url(diagram, config)
     # Download the image
     img_data = await download_image(
         url=img_url,

--- a/src/telegramify_markdown/pipeline.py
+++ b/src/telegramify_markdown/pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from telegramify_markdown.config import RenderConfig
 from telegramify_markdown.converter import Segment, convert_with_segments
 from telegramify_markdown.entity import MessageEntity, split_entities, utf16_len
 from telegramify_markdown.logger import logger
@@ -102,6 +103,7 @@ async def process_markdown(
     latex_escape: bool = True,
     render_mermaid: bool = True,
     min_file_lines: int = 1,
+    config: RenderConfig | None = None,
 ) -> list[Text | File | Photo]:
     """Full async pipeline: markdown → list of sendable content pieces.
 
@@ -114,6 +116,7 @@ async def process_markdown(
     :param min_file_lines: Minimum line count for a code block to be extracted
         as a separate file.  Set to ``0`` to disable file extraction entirely
         (all code blocks stay inline as ``pre`` entities).
+    :param config: Render configuration. Uses the global config if None.
 
     Pipeline steps:
 
@@ -125,7 +128,7 @@ async def process_markdown(
     3. Return ordered list of Text | File | Photo
     """
     full_text, full_entities, segments = convert_with_segments(
-        content, latex_escape=latex_escape
+        content, latex_escape=latex_escape, config=config
     )
 
     result: list[Text | File | Photo] = []
@@ -164,7 +167,7 @@ async def process_markdown(
 
         # Handle special segment
         if seg.kind == "mermaid":
-            await _handle_mermaid(result, seg)
+            await _handle_mermaid(result, seg, config)
         elif seg.kind == "code_block":
             _handle_code_block(result, seg)
 
@@ -182,9 +185,11 @@ async def process_markdown(
         if text_chunk:
             _append_text_chunks(result, text_chunk, text_entities, max_message_length)
 
-    # If no output was generated, emit empty text
-    if not result and full_text.strip():
-        _append_text_chunks(result, full_text.strip(), full_entities, max_message_length)
+    # The two branches above already cover every non-empty span of text: each
+    # segment before the cursor reaches the end goes through _append_text_chunks,
+    # and so does the remainder after it. No fallback branch here on purpose --
+    # the earlier one paired full_text.strip() with unadjusted full_entities, so
+    # it would have emitted misaligned entities had it ever fired.
 
     return result
 
@@ -232,6 +237,7 @@ def _handle_code_block(
 async def _handle_mermaid(
     result: list[Text | File | Photo],
     seg: Segment,
+    config: RenderConfig | None = None,
 ) -> None:
     """Render a mermaid diagram as a Photo, or fall back to File."""
     from telegramify_markdown.mermaid import support_mermaid
@@ -251,8 +257,8 @@ async def _handle_mermaid(
     try:
         from telegramify_markdown.mermaid import render_mermaid, get_mermaid_live_url
 
-        img_data, _caption_url = await render_mermaid(raw_code)
-        edit_url = get_mermaid_live_url(raw_code)
+        img_data, _caption_url = await render_mermaid(raw_code, config=config)
+        edit_url = get_mermaid_live_url(raw_code, config)
         # 用 text_link entity 避免长 URL 撑爆 caption 长度限制
         caption = "Edit on mermaid.live"
         result.append(

--- a/src/telegramify_markdown/rich.py
+++ b/src/telegramify_markdown/rich.py
@@ -106,14 +106,12 @@ class _RichHtmlWalker:
         self._code_block_lang = ""
         self._code_block_parts: list[str] = []
 
-        self._in_table = False
         self._in_table_head = False
         self._in_table_cell = False
         self._table_alignments: tuple = ()
         self._table_rows: list[list[tuple[str, bool]]] = []
         self._current_row: list[tuple[str, bool]] = []
         self._cell_parts: list[str] = []
-        self._cell_col = 0
 
         self._image: _ImageCapture | None = None
 
@@ -216,7 +214,6 @@ class _RichHtmlWalker:
             self._in_table_head = True
         elif tag == "TableRow":
             self._current_row = []
-            self._cell_col = 0
         elif tag == "TableCell":
             self._cell_parts = []
             self._in_table_cell = True
@@ -258,6 +255,12 @@ class _RichHtmlWalker:
         elif tag == "Strikethrough":
             self._close_inline()
         elif tag == "Paragraph":
+            self._close_paragraph()
+            self._leave_block()
+        elif tag == "HtmlBlock":
+            # Must pair with _on_start's _enter_block, otherwise _block_depth
+            # never returns to 0 and everything after this merges into a single
+            # RichBlock in walk_blocks, defeating the byte and block budgets.
             self._close_paragraph()
             self._leave_block()
         elif tag == "Item":
@@ -435,15 +438,12 @@ class _RichHtmlWalker:
 
     def _on_start_table(self, alignments) -> None:
         self._close_paragraph()
-        self._in_table = True
         self._table_alignments = alignments if isinstance(alignments, tuple) else ()
         self._table_rows = []
-        self._emit("")
 
     def _on_end_table_cell(self) -> None:
         content = "".join(self._cell_parts)
         self._current_row.append((content, self._in_table_head))
-        self._cell_col += 1
         self._cell_parts = []
         self._in_table_cell = False
 
@@ -451,10 +451,8 @@ class _RichHtmlWalker:
         if self._current_row:
             self._table_rows.append(self._current_row)
         self._current_row = []
-        self._cell_col = 0
 
     def _on_end_table(self) -> None:
-        self._in_table = False
         rows: list[str] = []
         for row in self._table_rows:
             cells: list[str] = []
@@ -634,17 +632,10 @@ def _split_html(
     html_content = rich_message.html
     assert html_content is not None
 
-    # 快速路径: 不需要拆分
-    byte_len = len(html_content.encode("utf-8"))
-    if byte_len <= byte_limit:
-        # 还需要检查 block 数，但无法精确得知 block 数不做 re-walk
-        # 对于单 payload 直接返回（richify 的输出最多 ~500 block 时才到这里）
-        # 实际 re-walk 以确保 block 数正确
-        pass
-
-    # 用简化的 walker 从 HTML 重构 block 列表不可行（会违反 single-parse-boundary）
-    # 但 split_rich 接受的是已构建的 InputRichMessage，无法回溯到 markdown 源
-    # 因此对于 split_rich(已构建 payload) 的情况，用标签启发式拆分
+    # split_rich() receives an already-built payload and cannot get back to the
+    # markdown source, so top-level blocks are recovered heuristically from tags.
+    # For exact block boundaries use telegramify_rich(), which consumes the
+    # walk_blocks result directly.
     blocks = _heuristic_html_blocks(html_content)
 
     return _bin_blocks(
@@ -937,7 +928,13 @@ def _flush_chunk(
 
 
 def _split_oversized_block(block: RichBlock, byte_limit: int) -> list[RichBlock]:
-    """Split oversized paragraph/pre blocks while preserving valid Rich HTML."""
+    """Split an oversized block while preserving valid Rich HTML.
+
+    Leaf blocks (``<p>`` / ``<pre>``) split by text; container blocks
+    (``<blockquote>`` / ``<ul>`` / ``<ol>`` / ``<table>``) split by direct child,
+    each part re-wrapped in the original open and close tags. An empty list means
+    the block could not be split, and the caller emits it as-is with a warning.
+    """
     html_text = block.html
 
     paragraph = _extract_wrapped_text(html_text, "p")
@@ -965,7 +962,101 @@ def _split_oversized_block(block: RichBlock, byte_limit: int) -> list[RichBlock]
             if part
         ]
 
+    container = _extract_container(html_text)
+    if container is not None:
+        return _split_container(*container, byte_limit=byte_limit)
+
     return []
+
+
+_CONTAINER_OPEN_RE = re.compile(r"<(blockquote|ul|ol|table)(?:\s[^>]*)?>")
+_OL_START_RE = re.compile(r'start="(\d+)"')
+
+
+def _extract_container(html_text: str) -> tuple[str, str, str, str] | None:
+    """If the fragment is exactly one splittable container, return
+    (open tag, inner HTML, close tag, tag name)."""
+    match = _CONTAINER_OPEN_RE.match(html_text)
+    if not match:
+        return None
+    tag = match.group(1)
+    close_tag = f"</{tag}>"
+    if not html_text.endswith(close_tag):
+        return None
+    # The close tag must pair with this open tag, not with a nested element
+    # of the same name
+    if _find_tag_end(html_text, 0, tag) != len(html_text):
+        return None
+    return match.group(0), html_text[match.end() : -len(close_tag)], close_tag, tag
+
+
+def _split_container(
+    open_tag: str,
+    inner: str,
+    close_tag: str,
+    tag: str,
+    *,
+    byte_limit: int,
+) -> list[RichBlock]:
+    """Split a container by direct child, re-wrapping each part in its tags."""
+    budget = byte_limit - len((open_tag + close_tag).encode("utf-8"))
+    if budget <= 0:
+        return []
+
+    children = _heuristic_html_blocks(inner)
+    if not children:
+        return []
+
+    # Split any single oversized child first, otherwise binning just produces
+    # one oversized bin
+    expanded: list[RichBlock] = []
+    for child in children:
+        if child.byte_len > budget:
+            pieces = _split_oversized_block(child, budget)
+            expanded.extend(pieces or [child])
+        else:
+            expanded.append(child)
+
+    groups: list[list[RichBlock]] = []
+    current: list[RichBlock] = []
+    current_bytes = 0
+    for child in expanded:
+        if current and current_bytes + child.byte_len > budget:
+            groups.append(current)
+            current = []
+            current_bytes = 0
+        current.append(child)
+        current_bytes += child.byte_len
+    if current:
+        groups.append(current)
+
+    if len(groups) <= 1:
+        return []
+
+    blocks: list[RichBlock] = []
+    items_before = 0
+    for group in groups:
+        blocks.append(
+            _make_block(
+                _reopen_tag(open_tag, tag, items_before)
+                + "".join(child.html for child in group)
+                + close_tag
+            )
+        )
+        # Count direct children only: <li> inside a nested list does not
+        # consume an outer ordinal
+        items_before += sum(1 for child in group if child.html.startswith("<li"))
+    return blocks
+
+
+def _reopen_tag(open_tag: str, tag: str, items_before: int) -> str:
+    """Continue an ordered list from the previous part's numbering instead of
+    restarting at 1."""
+    if tag != "ol" or items_before == 0:
+        return open_tag
+    match = _OL_START_RE.search(open_tag)
+    start = int(match.group(1)) if match else 1
+    return f'<ol start="{start + items_before}">'
 
 
 def _make_block(html_text: str) -> RichBlock:

--- a/src/telegramify_markdown/rich.py
+++ b/src/telegramify_markdown/rich.py
@@ -577,7 +577,7 @@ def richify(
     preprocessed = markdown
     if latex_escape:
         preprocessed = _escape_latex(preprocessed)
-    preprocessed = _preprocess_spoilers(preprocessed)
+    preprocessed = _preprocess_spoilers(preprocessed, RICH_OPTIONS)
 
     events = pyromark.events_with_range(preprocessed, options=RICH_OPTIONS)
     html_text = _RichHtmlWalker().walk(events)
@@ -597,7 +597,7 @@ def _walk_blocks_from_markdown(
     preprocessed = markdown
     if latex_escape:
         preprocessed = _escape_latex(preprocessed)
-    preprocessed = _preprocess_spoilers(preprocessed)
+    preprocessed = _preprocess_spoilers(preprocessed, RICH_OPTIONS)
     events = pyromark.events_with_range(preprocessed, options=RICH_OPTIONS)
     return _RichHtmlWalker().walk_blocks(events)
 
@@ -879,17 +879,20 @@ def _bin_blocks(
                 current_bytes = 0
                 current_block_count = 0
 
-            split_blocks = _split_oversized_block(block, byte_limit)
-            if split_blocks:
-                for split_block in split_blocks:
-                    _flush_chunk(chunks, [split_block], mode, is_rtl, skip_entity_detection)
-            else:
-                logger.warning(
-                    "单个 block 超过字节限制 (%d > %d)，独立发出。Telegram 可能拒绝。",
-                    block.byte_len,
-                    byte_limit,
-                )
-                _flush_chunk(chunks, [block], mode, is_rtl, skip_entity_detection)
+            split_blocks = _split_oversized_block(block, byte_limit) or [block]
+            for split_block in split_blocks:
+                # A split can still leave an atomic child over the limit -- a
+                # single 40KB list item, say. Warn per surviving part rather
+                # than only when splitting fails outright, otherwise a partial
+                # success hides the payload Telegram will reject.
+                if split_block.byte_len > byte_limit:
+                    logger.warning(
+                        "Rich block exceeds the byte limit (%d > %d) and cannot be "
+                        "split further; sending it alone. Telegram may reject it.",
+                        split_block.byte_len,
+                        byte_limit,
+                    )
+                _flush_chunk(chunks, [split_block], mode, is_rtl, skip_entity_detection)
             continue
 
         # 检查是否会超出预算
@@ -969,8 +972,14 @@ def _split_oversized_block(block: RichBlock, byte_limit: int) -> list[RichBlock]
     return []
 
 
-_CONTAINER_OPEN_RE = re.compile(r"<(blockquote|ul|ol|table)(?:\s[^>]*)?>")
-_OL_START_RE = re.compile(r'start="(\d+)"')
+# The attribute part tolerates a quoted value containing '>'. richify() always
+# escapes attributes, but split_rich() is public and may be handed HTML the
+# caller wrote, where a naive [^>]* would cut the open tag in the wrong place.
+_CONTAINER_OPEN_RE = re.compile(
+    r"""<(blockquote|ul|ol|table)(?:\s(?:"[^"]*"|'[^']*'|[^>"'])*)?>"""
+)
+_OL_START_RE = re.compile(r"""(?<![-\w])start\s*=\s*(?:"(\d+)"|'(\d+)')""")
+_OL_ANY_START_RE = re.compile(r"(?<![-\w])start\s*=")
 
 
 def _extract_container(html_text: str) -> tuple[str, str, str, str] | None:
@@ -999,12 +1008,20 @@ def _split_container(
     byte_limit: int,
 ) -> list[RichBlock]:
     """Split a container by direct child, re-wrapping each part in its tags."""
-    budget = byte_limit - len((open_tag + close_tag).encode("utf-8"))
-    if budget <= 0:
-        return []
-
     children = _heuristic_html_blocks(inner)
     if not children:
+        return []
+
+    # An <ol> continuation renumbers its opening tag, and a wider start number
+    # is a longer tag than the one we started from. Budget against the widest
+    # tag any part could get, or the last part overflows by those extra digits.
+    total_items = sum(1 for child in children if child.html.startswith("<li"))
+    widest_open = max(
+        len(open_tag.encode("utf-8")),
+        len(_reopen_tag(open_tag, tag, total_items).encode("utf-8")),
+    )
+    budget = byte_limit - widest_open - len(close_tag.encode("utf-8"))
+    if budget <= 0:
         return []
 
     # Split any single oversized child first, otherwise binning just produces
@@ -1051,12 +1068,27 @@ def _split_container(
 
 def _reopen_tag(open_tag: str, tag: str, items_before: int) -> str:
     """Continue an ordered list from the previous part's numbering instead of
-    restarting at 1."""
+    restarting at 1.
+
+    The start value is rewritten in place so any other attribute on the tag
+    survives. When the tag carries a ``start`` this cannot parse, the tag is
+    returned untouched: restarting the numbering is a display nit, whereas
+    appending a second ``start`` would emit invalid HTML.
+    """
     if tag != "ol" or items_before == 0:
         return open_tag
     match = _OL_START_RE.search(open_tag)
-    start = int(match.group(1)) if match else 1
-    return f'<ol start="{start + items_before}">'
+    if match:
+        group = 1 if match.group(1) is not None else 2
+        continued = int(match.group(group)) + items_before
+        return (
+            open_tag[: match.start(group)]
+            + str(continued)
+            + open_tag[match.end(group) :]
+        )
+    if _OL_ANY_START_RE.search(open_tag):
+        return open_tag
+    return f'<ol start="{1 + items_before}"' + open_tag[len("<ol") :]
 
 
 def _make_block(html_text: str) -> RichBlock:

--- a/src/telegramify_markdown/stream/draft.py
+++ b/src/telegramify_markdown/stream/draft.py
@@ -14,6 +14,20 @@ from telegramify_markdown.stream.core import StreamCore
 
 logger = logging.getLogger(__name__)
 
+# Telegram's per-message text limit, counted in UTF-16 code units.
+_DRAFT_TEXT_LIMIT = 4096
+
+
+def _tail_by_utf16(text: str, limit: int) -> str:
+    """Return the tail of text within limit UTF-16 code units, never splitting
+    a surrogate pair."""
+    total = 0
+    for i in range(len(text) - 1, -1, -1):
+        total += 2 if ord(text[i]) > 0xFFFF else 1
+        if total > limit:
+            return text[i + 1 :]
+    return text
+
 
 @dataclasses.dataclass(slots=True)
 class EntityDraftPayload:
@@ -132,15 +146,20 @@ class DraftStream:
             return self._render_rich(buffer)
 
     def _render_entity(self, buffer: str):
-        """Entity 模式渲染：convert() + 尾部 4096 字符截断。"""
+        """Entity mode: convert(), then trim the tail to Telegram's 4096 limit."""
         from telegramify_markdown.converter import convert
+        from telegramify_markdown.entity import utf16_len
 
         text, entities = convert(buffer)
 
-        # sliding window: 只取尾部 4096 字符
-        # draft 是临时显示，截断后 entities 偏移会失效，直接丢弃
-        if len(text) > 4096:
-            text = text[-4096:]
+        # Sliding window: keep only the trailing 4096 UTF-16 code units.
+        # It has to be measured in UTF-16, not Python characters: astral
+        # characters such as emoji take two code units each, so truncating by
+        # character can emit twice the allowed length and Telegram rejects it.
+        # A draft is transient, and truncation invalidates entity offsets, so
+        # the entities are dropped.
+        if utf16_len(text) > _DRAFT_TEXT_LIMIT:
+            text = _tail_by_utf16(text, _DRAFT_TEXT_LIMIT)
             entities = []
 
         return EntityDraftPayload(

--- a/src/telegramify_markdown/stream/edit.py
+++ b/src/telegramify_markdown/stream/edit.py
@@ -9,7 +9,7 @@ via send_message, then updates it with edit_message on each throttle tick.
 from __future__ import annotations
 
 import logging
-from typing import Awaitable, Callable, Literal, Optional
+from typing import Callable, Literal, Optional
 
 from telegramify_markdown.stream.core import StreamCore
 from telegramify_markdown.stream.draft import (

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -768,6 +768,22 @@ class BlockSpacingAfterListTest(unittest.TestCase):
         text, _ = convert("- a\n- b\n# h", latex_escape=False)
         self.assertNotIn("\n\n", text)
 
+    def test_all_line_endings_are_recognised(self):
+        # CommonMark accepts bare CR as a line ending; counting only LF loses
+        # the blank line on CR-terminated input.
+        for name, source, blank_expected in (
+            ("lf", "a\n\n# h", True),
+            ("lf-tight", "a\n# h", False),
+            ("cr", "a\r\r# h", True),
+            ("cr-tight", "a\r# h", False),
+            ("crlf", "a\r\n\r\n# h", True),
+            ("crlf-tight", "a\r\n# h", False),
+            ("cr-in-blockquote", "> a\r>\r> # h", True),
+        ):
+            with self.subTest(name=name):
+                text, _ = convert(source, latex_escape=False)
+                self.assertEqual("\n\n" in text, blank_expected, repr(text))
+
 
 class SpoilerCodeRegionTest(unittest.TestCase):
     """Spoiler preprocessing must not rewrite code block content."""
@@ -796,6 +812,70 @@ class SpoilerCodeRegionTest(unittest.TestCase):
         self.assertIn("||a||", text)
         self.assertIsNone(_find_entity(entities, "spoiler"))
 
+    def test_single_line_triple_backtick_does_not_open_a_fence(self):
+        # A backtick fence's info string may not contain a backtick, so
+        # ```x``` on one line is a code span, not the start of a block.
+        # Reading it as a fence swallowed everything up to the next fence and
+        # silently disabled spoilers in between.
+        md = '```print("x")```\n\n||secret||\n\n```py\ncode\n```\n'
+        text, entities = convert(md, latex_escape=False)
+        spoiler = _find_entity(entities, "spoiler")
+        self.assertIsNotNone(spoiler)
+        self.assertEqual(_extract_entity_text(text, spoiler), "secret")
+
+    def test_info_string_without_backtick_still_opens_a_fence(self):
+        text, entities = convert("```python title\n||x||\n```", latex_escape=False)
+        self.assertIn("||x||", text)
+        self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_fence_inside_blockquote_is_code(self):
+        # A fence can sit behind a container prefix. Missing that rewrites the
+        # quoted code instead of leaving it alone.
+        text, entities = convert("> ```\n> a || b || c\n> ```", latex_escape=False)
+        self.assertIn("a || b || c", text)
+        self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_fence_inside_list_item_is_code(self):
+        text, entities = convert("- ```\n  a || b || c\n  ```", latex_escape=False)
+        self.assertIn("a || b || c", text)
+        self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_multi_backtick_inline_code_is_skipped(self):
+        text, entities = convert("x ``a || b || c`` y", latex_escape=False)
+        self.assertIn("a || b || c", text)
+        self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_container_and_fence_shapes_never_rewrite_code(self):
+        # Every shape a hand-rolled line scanner got wrong. The parser decides
+        # what is code now, so these must all survive untouched.
+        for name, source in (
+            ("blockquote fence", "> ```\n> ||x||\n> ```"),
+            ("nested blockquote fence", "> > ```\n> > ||x||\n> > ```"),
+            ("list item fence", "- ```\n  ||x||\n  ```"),
+            ("indented code, many lines", "    a\n    ||x||"),
+            ("indented fence-looking code", "    ```\n    ||x||\n    ```"),
+            ("invalid closing fence", "```\na\n```oops\n||x||\n```"),
+            ("paragraph line that looks like a list", "para\n2. fake\n\n    ||x||"),
+            ("tab indented code", "\ta\n\t||x||"),
+        ):
+            with self.subTest(name=name):
+                text, entities = convert(source, latex_escape=False)
+                self.assertIn("||x||", text)
+                self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_spoiler_still_applies_outside_code(self):
+        for name, source in (
+            ("plain", "a ||x|| b"),
+            ("list item", "- ||x||"),
+            ("blockquote", "> ||x||"),
+            ("deeply indented list item", "- a\n    - ||x||"),
+            ("paragraph continuation", "p\n    ||x||"),
+            ("html block nearby", "<div>\n```\n</div>\n\n||x||"),
+        ):
+            with self.subTest(name=name):
+                _, entities = convert(source, latex_escape=False)
+                self.assertIsNotNone(_find_entity(entities, "spoiler"))
+
     def test_spoiler_in_deeply_indented_list_still_works(self):
         # A list item indented four spaces is not an indented code block, so
         # the spoiler must still apply
@@ -823,6 +903,16 @@ class MultilineSpoilerTest(unittest.TestCase):
         self.assertIn("line1", text)
         self.assertIn("line2", text)
         self.assertIsNotNone(_find_entity(entities, "spoiler"))
+
+    def test_crlf_wrapped_spoiler_survives(self):
+        # Stripping only "\n" leaves the leading "\r", which still puts the
+        # open tag alone on its line under CRLF input and drops the span.
+        for source in ("||\r\nsecret\r\n||", "||\rsecret\r||", "||\r\nsecret\n||"):
+            with self.subTest(source=source):
+                text, entities = convert(source, latex_escape=False)
+                spoiler = _find_entity(entities, "spoiler")
+                self.assertIsNotNone(spoiler)
+                self.assertEqual(_extract_entity_text(text, spoiler), "secret")
 
 
 class ImageInTableCellTest(unittest.TestCase):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -739,5 +739,246 @@ class TaskListMarkerTest(unittest.TestCase):
         self.assertIn("✅", text)
 
 
+class BlockSpacingAfterListTest(unittest.TestCase):
+    """A block after a list must keep the blank line the source had.
+
+    pyromark's End(List) range already includes the trailing blank line, so the
+    old "gap between previous block end and next block start" test always
+    concluded there was no blank line after a list.
+    """
+
+    def test_paragraph_after_list_keeps_blank_line(self):
+        text, _ = convert("- a\n- b\n\npara", latex_escape=False)
+        self.assertIn("\n\npara", text)
+
+    def test_ordered_list_then_heading_keeps_blank_line(self):
+        text, _ = convert("1. a\n2. b\n\n# h", latex_escape=False)
+        self.assertIn("\n\n", text.split("b")[1])
+
+    def test_all_block_kinds_after_list_keep_blank_line(self):
+        followers = ["para", "# h", "```py\nx=1\n```", "> q", "---", "$$e^x$$"]
+        for follower in followers:
+            with self.subTest(follower=follower):
+                text, _ = convert(f"- a\n- b\n\n{follower}", latex_escape=False)
+                self.assertIn("\n\n", text)
+
+    def test_tight_list_then_block_has_no_blank_line(self):
+        # No blank line in the source means none invented (a heading may
+        # interrupt a list)
+        text, _ = convert("- a\n- b\n# h", latex_escape=False)
+        self.assertNotIn("\n\n", text)
+
+
+class SpoilerCodeRegionTest(unittest.TestCase):
+    """Spoiler preprocessing must not rewrite code block content."""
+
+    def test_tilde_fence_not_rewritten(self):
+        text, entities = convert("~~~py\n||x||\n~~~", latex_escape=False)
+        self.assertEqual(text, "||x||")
+        self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_indented_code_not_rewritten(self):
+        text, entities = convert("para\n\n    ||x||\n\ntail", latex_escape=False)
+        self.assertIn("||x||", text)
+        self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_tilde_inside_backtick_fence_does_not_close_it(self):
+        text, _ = convert("```\n~~~\n||a||\n```", latex_escape=False)
+        self.assertIn("||a||", text)
+
+    def test_shorter_fence_does_not_close_longer_one(self):
+        text, _ = convert("````\n||a||\n```\n||b||\n````", latex_escape=False)
+        self.assertIn("||a||", text)
+        self.assertIn("||b||", text)
+
+    def test_unterminated_fence_runs_to_end(self):
+        text, entities = convert("```\n||a||", latex_escape=False)
+        self.assertIn("||a||", text)
+        self.assertIsNone(_find_entity(entities, "spoiler"))
+
+    def test_spoiler_in_deeply_indented_list_still_works(self):
+        # A list item indented four spaces is not an indented code block, so
+        # the spoiler must still apply
+        text, entities = convert("- a\n    - ||x||\n", latex_escape=False)
+        self.assertIsNotNone(_find_entity(entities, "spoiler"))
+        self.assertNotIn("||", text)
+
+    def test_spoiler_in_paragraph_continuation_still_works(self):
+        text, entities = convert("para\n    ||x|| cont\n", latex_escape=False)
+        self.assertIsNotNone(_find_entity(entities, "spoiler"))
+
+
+class MultilineSpoilerTest(unittest.TestCase):
+    """An open tag alone on a line becomes a CommonMark HTML block, and the
+    whole span gets dropped."""
+
+    def test_newline_wrapped_spoiler_survives(self):
+        text, entities = convert("||\nsecret\n||", latex_escape=False)
+        spoiler = _find_entity(entities, "spoiler")
+        self.assertIsNotNone(spoiler)
+        self.assertEqual(_extract_entity_text(text, spoiler), "secret")
+
+    def test_multiline_content_preserved(self):
+        text, entities = convert("||\nline1\nline2\n||", latex_escape=False)
+        self.assertIn("line1", text)
+        self.assertIn("line2", text)
+        self.assertIsNotNone(_find_entity(entities, "spoiler"))
+
+
+class ImageInTableCellTest(unittest.TestCase):
+    """An image symbol in a cell must stay inside the rendered table."""
+
+    def test_image_symbol_stays_inside_table(self):
+        md = "| a |\n|---|\n| ![alt](https://e.com/i.png) |"
+        text, entities = convert(md, latex_escape=False)
+        pre = _find_entity(entities, "pre")
+        self.assertIsNotNone(pre)
+        # pre covering the whole span means the image symbol did not leak out
+        # ahead of the table
+        self.assertEqual(pre.offset, 0)
+        self.assertEqual(pre.length, utf16_len(text))
+        self.assertIn("🖼alt", text)
+
+
+class ListMarkerConfigTest(unittest.TestCase):
+    """@see https://github.com/sudoskys/telegramify-markdown/issues/116"""
+
+    def setUp(self):
+        from telegramify_markdown.config import get_runtime_config
+
+        self.symbol = get_runtime_config().markdown_symbol
+        self._saved = (self.symbol.unordered_list_item, self.symbol.ordered_list_suffix)
+
+    def tearDown(self):
+        self.symbol.unordered_list_item, self.symbol.ordered_list_suffix = self._saved
+
+    def test_default_is_unchanged(self):
+        text, _ = convert("- a\n- b", latex_escape=False)
+        self.assertIn("⦁ a", text)
+
+    def test_custom_unordered_marker(self):
+        self.symbol.unordered_list_item = "-"
+        text, _ = convert("- a\n- b", latex_escape=False)
+        self.assertIn("- a", text)
+        self.assertNotIn("⦁", text)
+
+    def test_custom_marker_applies_to_nested_items(self):
+        self.symbol.unordered_list_item = "•"
+        text, _ = convert("- a\n  - b", latex_escape=False)
+        self.assertIn("• a", text)
+        self.assertIn("  • b", text)
+
+    def test_custom_ordered_suffix(self):
+        self.symbol.ordered_list_suffix = ")"
+        text, _ = convert("1. a\n2. b", latex_escape=False)
+        self.assertIn("1) a", text)
+        self.assertIn("2) b", text)
+
+    def test_task_marker_still_replaces_custom_bullet(self):
+        self.symbol.unordered_list_item = "-"
+        text, _ = convert("- [x] done", latex_escape=False)
+        self.assertIn("✅", text)
+        self.assertNotIn("- [", text)
+        self.assertFalse(text.startswith("-"))
+
+
+class RenderConfigIsolationTest(unittest.TestCase):
+    """The global config is shared mutable state; isolated() hands out copies
+    that do not affect each other.
+
+    Mutating the global inside concurrent handlers crosses configurations:
+    pyTelegramBotAPI is multi-threaded by default, and on the asyncio side
+    "mutate global -> await -> render" always yields control in between.
+    """
+
+    def setUp(self):
+        from telegramify_markdown.config import get_runtime_config
+
+        self.symbol = get_runtime_config().markdown_symbol
+        self._saved = self.symbol.unordered_list_item
+
+    def tearDown(self):
+        self.symbol.unordered_list_item = self._saved
+
+    def test_bare_construction_still_returns_global(self):
+        # 1.x compatibility: RenderConfig() is equivalent to get_runtime_config()
+        from telegramify_markdown.config import RenderConfig, get_runtime_config
+
+        self.assertIs(RenderConfig(), get_runtime_config())
+        self.assertIs(RenderConfig(), RenderConfig())
+
+    def test_repeated_construction_does_not_reset_settings(self):
+        from telegramify_markdown.config import RenderConfig
+
+        RenderConfig().markdown_symbol.unordered_list_item = "@"
+        self.assertEqual(RenderConfig().markdown_symbol.unordered_list_item, "@")
+
+    def test_isinstance_works(self):
+        # Under the decorator implementation RenderConfig was a function and
+        # isinstance raised TypeError
+        from telegramify_markdown.config import RenderConfig, get_runtime_config
+
+        self.assertIsInstance(get_runtime_config(), RenderConfig)
+        self.assertIsInstance(RenderConfig.isolated(), RenderConfig)
+
+    def test_isolated_starts_from_defaults_and_stays_independent(self):
+        from telegramify_markdown.config import RenderConfig, get_runtime_config
+
+        get_runtime_config().markdown_symbol.unordered_list_item = "@"
+        isolated = RenderConfig.isolated()
+        self.assertEqual(isolated.markdown_symbol.unordered_list_item, "⦁")
+
+        isolated.markdown_symbol.unordered_list_item = "*"
+        self.assertEqual(get_runtime_config().markdown_symbol.unordered_list_item, "@")
+
+    def test_copy_inherits_current_values_but_is_independent(self):
+        from telegramify_markdown.config import get_runtime_config
+
+        get_runtime_config().markdown_symbol.unordered_list_item = "@"
+        clone = get_runtime_config().copy()
+        self.assertEqual(clone.markdown_symbol.unordered_list_item, "@")
+
+        clone.markdown_symbol.unordered_list_item = "#"
+        self.assertEqual(get_runtime_config().markdown_symbol.unordered_list_item, "@")
+
+    def test_two_isolated_configs_render_differently(self):
+        from telegramify_markdown.config import RenderConfig
+
+        dash = RenderConfig.isolated()
+        dash.markdown_symbol.unordered_list_item = "-"
+        bullet = RenderConfig.isolated()
+        bullet.markdown_symbol.unordered_list_item = "•"
+
+        self.assertIn("- x", convert("- x", config=dash, latex_escape=False)[0])
+        self.assertIn("• x", convert("- x", config=bullet, latex_escape=False)[0])
+
+    def test_concurrent_threads_do_not_share_isolated_config(self):
+        import threading
+
+        from telegramify_markdown.config import RenderConfig
+
+        rendered = {}
+        aligned = threading.Barrier(2)
+
+        def handler(name: str, marker: str) -> None:
+            cfg = RenderConfig.isolated()
+            cfg.markdown_symbol.unordered_list_item = marker
+            aligned.wait()  # render only after both threads have configured,
+            # maximising the chance of crossing configurations
+            rendered[name] = convert("- item", config=cfg, latex_escape=False)[0].strip()
+
+        threads = [
+            threading.Thread(target=handler, args=("a", "-")),
+            threading.Thread(target=handler, args=("b", "•")),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(rendered["a"], "- item")
+        self.assertEqual(rendered["b"], "• item")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,5 +1,4 @@
 import unittest
-
 from telegramify_markdown.entity import MessageEntity, utf16_len, split_entities
 
 
@@ -214,6 +213,42 @@ class SplitEntitiesTest(unittest.TestCase):
         self.assertEqual(combined, text)
         for chunk_text, _ in result:
             self.assertLessEqual(utf16_len(chunk_text), 4)
+
+
+class Utf16LenTest(unittest.TestCase):
+    """utf16_len must stay exactly equivalent to the per-character definition.
+
+    It is the primitive every entity offset is measured with, so a divergence
+    silently misplaces formatting rather than failing loudly.
+    """
+
+    @staticmethod
+    def _per_character(text: str) -> int:
+        total = 0
+        for ch in text:
+            total += 2 if ord(ch) > 0xFFFF else 1
+        return total
+
+    def test_matches_per_character_definition(self):
+        samples = [
+            "",
+            "abc",
+            "中文",
+            "😀",
+            "a\U0001f600b",
+            "🎉中a",
+            "\t\n ",
+        ]
+        for sample in samples:
+            with self.subTest(sample=sample):
+                self.assertEqual(utf16_len(sample), self._per_character(sample))
+
+    def test_lone_surrogates_are_counted_not_rejected(self):
+        # A plain utf-16-le encode raises on these. They reach the library from
+        # surrogateescape decoding, and 1.x counted them as one code unit.
+        for sample in ("\ud800", "\udfff", "a\ud800b", "".join(chr(c) for c in range(0xD800, 0xD810))):
+            with self.subTest(sample=repr(sample)):
+                self.assertEqual(utf16_len(sample), self._per_character(sample))
 
 
 if __name__ == "__main__":

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,79 @@
+"""Complexity regression tests for the conversion paths.
+
+These assert a *ratio* -- quadrupling the input must not multiply the time by
+more than ten -- rather than an absolute duration. Absolute timings depend on
+the machine; the ratio does not. A linear implementation lands around 4x and a
+quadratic one around 16x, so a 10x threshold separates them cleanly while
+leaving room for CI noise.
+
+Two quadratic regressions have shipped here before:
+- _TextBuffer.py_offset recomputed sum(len(p) for p in _parts) on every read,
+  and _on_start_item reads it once per list item; a 4000-item document took
+  400ms.
+- The MarkdownV2 blockquote lookup scanned bq_ranges linearly once per line;
+  a 43KB all-quote document took 161ms.
+"""
+
+import time
+import unittest
+
+from telegramify_markdown import convert, markdownify
+
+# Maximum time growth allowed for 4x the input. Linear is ~4x, quadratic ~16x.
+_MAX_GROWTH = 10.0
+
+
+def _best_of(fn, rounds: int = 3) -> float:
+    """Take the minimum across rounds to mask GC and scheduler noise."""
+    best = float("inf")
+    for _ in range(rounds):
+        start = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - start)
+    return best
+
+
+class ConversionScalingTest(unittest.TestCase):
+    def _assert_scales_linearly(self, build, small: int, large: int):
+        self.assertEqual(large, small * 4, "the threshold assumes a 4x step")
+        small_time = _best_of(lambda: convert(build(small), latex_escape=False))
+        large_time = _best_of(lambda: convert(build(large), latex_escape=False))
+        growth = large_time / small_time
+        self.assertLess(
+            growth,
+            _MAX_GROWTH,
+            f"{small}->{large} grew {growth:.1f}x "
+            f"({small_time * 1000:.2f}ms -> {large_time * 1000:.2f}ms), "
+            f"suspected quadratic complexity",
+        )
+
+    def test_list_items_scale_linearly(self):
+        self._assert_scales_linearly(
+            lambda n: "\n".join(f"- item {i}" for i in range(n)), 500, 2000
+        )
+
+    def test_paragraphs_scale_linearly(self):
+        self._assert_scales_linearly(
+            lambda n: "\n\n".join(f"para {i}" for i in range(n)), 500, 2000
+        )
+
+
+class MarkdownV2ScalingTest(unittest.TestCase):
+    def test_blockquotes_scale_linearly(self):
+        def build(n: int) -> str:
+            return "\n\n".join("> quote line\n> second line" for _ in range(n))
+
+        small_time = _best_of(lambda: markdownify(build(400)))
+        large_time = _best_of(lambda: markdownify(build(1600)))
+        growth = large_time / small_time
+        self.assertLess(
+            growth,
+            _MAX_GROWTH,
+            f"400->1600 quotes grew {growth:.1f}x "
+            f"({small_time * 1000:.2f}ms -> {large_time * 1000:.2f}ms), "
+            f"suspected quadratic complexity",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -122,5 +122,77 @@ class ProcessMarkdownTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(results[0].entities[0].language, "mermaid")
 
 
+class DeprecatedArgumentTest(unittest.IsolatedAsyncioTestCase):
+    """0.x compatibility parameters on telegramify().
+
+    max_message_length = max_word_count used to sit inside the
+    normalize_whitespace branch: the alias silently did nothing, and
+    normalize_whitespace=True set the length limit to None and then crashed.
+    """
+
+    async def test_max_word_count_still_limits_length(self):
+        import warnings
+
+        from telegramify_markdown import telegramify
+        from telegramify_markdown.entity import utf16_len
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            results = await telegramify("x\n\n" * 400, max_word_count=100)
+
+        self.assertGreater(len(results), 1)
+        for item in results:
+            self.assertLessEqual(utf16_len(item.text), 100)
+
+    async def test_normalize_whitespace_does_not_break_splitting(self):
+        import warnings
+
+        from telegramify_markdown import telegramify
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            results = await telegramify("hello\n\nworld", normalize_whitespace=True)
+
+        self.assertEqual(len(results), 1)
+        self.assertIn("hello", results[0].text)
+
+
+class ConfigThreadingTest(unittest.IsolatedAsyncioTestCase):
+    """config= must reach all the way down, or the parameter name promises
+    something it cannot deliver."""
+
+    async def test_telegramify_honours_isolated_config(self):
+        from telegramify_markdown import telegramify
+        from telegramify_markdown.config import RenderConfig, get_runtime_config
+
+        cfg = RenderConfig.isolated()
+        cfg.markdown_symbol.unordered_list_item = "-"
+
+        results = await telegramify("- x", config=cfg)
+        self.assertIn("- x", results[0].text)
+        # The global was not modified by this call
+        self.assertEqual(
+            get_runtime_config().markdown_symbol.unordered_list_item, "⦁"
+        )
+
+    async def test_markdownify_honours_isolated_config(self):
+        from telegramify_markdown import markdownify
+        from telegramify_markdown.config import RenderConfig
+
+        cfg = RenderConfig.isolated()
+        cfg.markdown_symbol.unordered_list_item = "•"
+        self.assertIn("• x", markdownify("- x", config=cfg, latex_escape=False))
+
+    async def test_mermaid_settings_follow_the_given_config(self):
+        from telegramify_markdown.config import RenderConfig
+        from telegramify_markdown.mermaid import get_mermaid_ink_url
+
+        cfg = RenderConfig.isolated()
+        cfg.mermaid.width = 4242
+        self.assertIn("width=4242", get_mermaid_ink_url("graph TD\nA-->B", cfg))
+        # Without config= it still uses the global defaults
+        self.assertIn("width=1000", get_mermaid_ink_url("graph TD\nA-->B"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rich.py
+++ b/tests/test_rich.py
@@ -431,6 +431,97 @@ class OversizedContainerSplitTest(unittest.TestCase):
         chunks = self._chunks("# t\n\npara\n\n- a\n- b\n")
         self.assertEqual(len(chunks), 1)
 
+    def test_ordered_list_renumbering_never_overflows_the_limit(self):
+        # A continued <ol start="N"> is a longer opening tag than the original
+        # once N gains a digit. Budgeting against the original tag let the last
+        # parts overflow by exactly those extra bytes.
+        for limit in (60, 80, 120, 200):
+            with self.subTest(limit=limit):
+                from telegramify_markdown.rich import _bin_blocks
+
+                blocks = _walk_blocks_from_markdown(
+                    "\n".join(f"1. {'B' * 20}" for _ in range(30))
+                )
+                chunks = _bin_blocks(
+                    blocks,
+                    byte_limit=limit,
+                    block_limit=500,
+                    is_rtl=None,
+                    skip_entity_detection=None,
+                    mode="html",
+                )
+                self.assertGreater(len(chunks), 1)
+                for chunk in chunks:
+                    self.assertLessEqual(len(chunk.html.encode("utf-8")), limit)
+                # numbering still continues rather than restarting
+                self.assertTrue(chunks[0].html.startswith('<ol start="1">'))
+                self.assertNotIn('<ol start="1">', chunks[-1].html)
+
+    def test_unsplittable_oversized_child_still_warns(self):
+        # A single 40KB list item cannot be split further. Splitting the
+        # surrounding <ul> partially succeeds, which used to bypass the warning
+        # and emit an over-limit payload silently.
+        from telegramify_markdown.rich import RICH_BYTE_LIMIT
+
+        with self.assertLogs("telegramify_markdown.rich", level="WARNING") as logs:
+            items = telegramify_rich("- " + "A" * 40000 + "\n- b")
+
+        oversized = [
+            item
+            for item in items
+            if len(item.rich_message.html.encode("utf-8")) > RICH_BYTE_LIMIT
+        ]
+        self.assertEqual(len(oversized), 1)
+        self.assertTrue(any("cannot be split further" in line for line in logs.output))
+
+
+class CallerAuthoredHtmlSplitTest(unittest.TestCase):
+    """split_rich() is public, so it also receives HTML the caller wrote.
+
+    richify() escapes every attribute and only ever emits `<ol start="N">`, so
+    none of these shapes come out of the library itself — but rewriting the
+    open tag must not invent invalid HTML for them either.
+    """
+
+    def _split(self, html: str, byte_limit: int) -> list[str]:
+        return [chunk.html for chunk in split_rich(InputRichMessage(html=html), byte_limit=byte_limit)]
+
+    def test_single_quoted_start_is_continued_not_duplicated(self):
+        parts = self._split(
+            "<ol start='98'><li>AAAAAAAAAA</li><li>BBBBBBBBBB</li></ol>", 45
+        )
+        self.assertEqual(len(parts), 2)
+        self.assertIn("start='99'", parts[1])
+        self.assertEqual(parts[1].count("start="), 1)
+
+    def test_similarly_named_attribute_is_not_rewritten(self):
+        parts = self._split(
+            '<ol data-start="98" start="7"><li>AAAAAAAAAA</li><li>BBBBBBBBBB</li></ol>', 45
+        )
+        self.assertIn('data-start="98"', parts[1])
+        self.assertIn('start="8"', parts[1])
+
+    def test_unparsable_start_leaves_the_tag_alone(self):
+        parts = self._split(
+            '<ol start="abc"><li>AAAAAAAAAA</li><li>BBBBBBBBBB</li></ol>', 45
+        )
+        for part in parts:
+            self.assertEqual(part.count("start="), 1)
+            self.assertIn('start="abc"', part)
+
+    def test_quoted_attribute_containing_gt_keeps_the_open_tag_intact(self):
+        html = (
+            "<ol start='98' data-x='a>b'>"
+            + "".join(f"<li>{'A' * 10}</li>" for _ in range(3))
+            + "</ol>"
+        )
+        parts = self._split(html, 60)
+        self.assertGreater(len(parts), 1)
+        for part in parts:
+            self.assertIn("data-x='a>b'", part)
+            self.assertTrue(part.endswith("</ol>"))
+            self.assertLessEqual(len(part.encode("utf-8")), 60)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rich.py
+++ b/tests/test_rich.py
@@ -361,5 +361,76 @@ class TelegramifyRichTest(unittest.TestCase):
         self.assertIsNotNone(rich.html)
 
 
+class HtmlBlockBoundaryTest(unittest.TestCase):
+    """HtmlBlock must leave the block scope it entered.
+
+    Without _leave_block, _block_depth never returns to 0 and everything after
+    an HTML block merges into a single RichBlock, defeating the byte and block
+    budgets.
+    """
+
+    def test_blocks_after_html_block_stay_separate(self):
+        blocks = _walk_blocks_from_markdown("para1\n\n<div>raw</div>\n\npara2\n\npara3")
+        self.assertEqual(len(blocks), 4)
+        self.assertEqual(blocks[-1].html, "<p>para3</p>")
+
+    def test_paragraph_after_html_block_is_not_glued(self):
+        html = richify("<div>raw</div>\n\npara2").html
+        self.assertIn("<p>para2</p>", html)
+
+
+class OversizedContainerSplitTest(unittest.TestCase):
+    """Oversized container blocks split by child instead of going out whole
+    for Telegram to reject."""
+
+    LIMIT = 4096
+
+    def _chunks(self, markdown: str):
+        from telegramify_markdown.rich import _bin_blocks
+
+        blocks = _walk_blocks_from_markdown(markdown)
+        return _bin_blocks(
+            blocks,
+            byte_limit=self.LIMIT,
+            block_limit=500,
+            is_rtl=None,
+            skip_entity_detection=None,
+            mode="html",
+        )
+
+    def _assert_within_limit(self, chunks):
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk.html.encode("utf-8")), self.LIMIT)
+
+    def test_oversized_blockquote(self):
+        self._assert_within_limit(self._chunks("> " + "x" * 10000))
+
+    def test_oversized_table_splits_by_row(self):
+        rows = "\n".join(f"| {'y' * 100} | {'z' * 100} |" for _ in range(60))
+        chunks = self._chunks("| a | b |\n|---|---|\n" + rows)
+        self._assert_within_limit(chunks)
+        for chunk in chunks:
+            self.assertTrue(chunk.html.startswith("<table>"))
+            self.assertTrue(chunk.html.endswith("</table>"))
+
+    def test_oversized_unordered_list_splits_by_item(self):
+        chunks = self._chunks("\n".join(f"- {'i' * 200}" for _ in range(60)))
+        self._assert_within_limit(chunks)
+        for chunk in chunks:
+            self.assertTrue(chunk.html.startswith("<ul>"))
+
+    def test_oversized_ordered_list_continues_numbering(self):
+        chunks = self._chunks("\n".join(f"{i + 1}. {'i' * 200}" for i in range(60)))
+        self._assert_within_limit(chunks)
+        self.assertTrue(chunks[0].html.startswith('<ol start="1">'))
+        first_items = chunks[0].html.count("<li>")
+        self.assertTrue(chunks[1].html.startswith(f'<ol start="{1 + first_items}">'))
+
+    def test_content_within_limit_is_untouched(self):
+        chunks = self._chunks("# t\n\npara\n\n- a\n- b\n")
+        self.assertEqual(len(chunks), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -717,3 +717,27 @@ class TestDraftStreamSlidingWindow:
 
         assert payload.text == "Hello world"
         assert payload.entities == entities
+
+    def test_entity_truncation_counts_utf16_units(self):
+        """The sliding window counts UTF-16 code units, not Python characters.
+
+        Astral characters take two code units each, so truncating by character
+        emits twice the allowed length and Telegram rejects the draft.
+        """
+        from telegramify_markdown.entity import utf16_len
+        from telegramify_markdown.stream.draft import DraftStream
+
+        long_text = "😀" * 5000  # 5000 characters = 10000 UTF-16 code units
+
+        with patch("telegramify_markdown.converter.convert", return_value=(long_text, [])):
+            stream = DraftStream(
+                send_draft=AsyncMock(),
+                send_final=AsyncMock(),
+                mode="entity",
+                thinking_delay=None,
+            )
+            payload = stream._render_entity("x")
+
+        assert utf16_len(payload.text) <= 4096
+        # Must not split a surrogate pair
+        assert payload.text == "😀" * 2048


### PR DESCRIPTION
## What this is

A review pass over the library: 18 defects, each reproduced before it was fixed
and covered by a regression test. Plus the configurable list marker from #116
and a `py.typed` marker.

## Correctness

| Defect | Symptom |
|---|---|
| `telegramify()` deprecated args | `max_word_count=N` was silently ignored; `normalize_whitespace=True` raised `TypeError`. The assignment sat in the wrong branch. |
| Blank line after lists | Every block following a list lost its blank-line separation. pyromark's `End(List)` range already swallows the trailing blank line, so the previous-block-end gap heuristic always saw none. |
| Spoiler preprocessing | `\|\|x\|\|` inside `~~~` fences and indented code was rewritten into literal `<tg-spoiler>` markup, corrupting user code. |
| Newline-wrapped spoiler | `\|\|\nsecret\n\|\|` put `<tg-spoiler>` alone on a line, making it a CommonMark HTML block; the converter drops `Html` events, so the whole span vanished. |
| Rich `HtmlBlock` | Never left its block scope, so `_block_depth` never returned to 0 and everything after an HTML block merged into one `RichBlock`, defeating the byte and block budgets. |
| Draft sliding window | Truncated by Python character, emitting up to 8192 UTF-16 code units against Telegram's 4096 limit for astral text. |
| Oversized Rich containers | `<blockquote>`, `<ul>`, `<ol>`, `<table>` went out over the byte limit with only a warning. They now split by direct child, ordered lists continuing their numbering. |
| Image in a table cell | Wrote its symbol straight to the main buffer, leaking it ahead of the rendered table and outside the `pre` entity. |

## Complexity

Two quadratic paths, both on the shapes LLM output produces most.

| | Before | After |
|---|---|---|
| `convert()`, 4000 list items (46KB) | 395ms | 11.5ms |
| `markdownify()`, 1600 blockquotes (43KB) | 161ms | 15.8ms |

`_TextBuffer.py_offset` recomputed `sum(len(p) for p in _parts)` on every read
while `_on_start_item` reads it once per list item — 98.7% of the profile sat on
that one line. The MarkdownV2 blockquote lookup scanned `bq_ranges` linearly
once per line; a prefix-max-of-end bisect replaces it.

Also: `utf16_len` gets an ASCII fast path plus a C-level encode, MarkdownV2
escaping uses `str.translate`, and a 507-entry LaTeX probe table is built once
instead of per call.

`tests/test_performance.py` guards both quadratic paths by asserting a growth
ratio rather than an absolute duration. Both original implementations were
re-checked against it and exceed the threshold.

## Configuration scoping

`RenderConfig` was a decorator-built singleton, so `RenderConfig()` could only
ever return the one global object and `isinstance()` raised `TypeError`.
Concurrent handlers setting symbols on the global crossed configurations
silently — pyTelegramBotAPI runs handlers on multiple threads by default.

The singleton moved to `__new__`, which keeps `RenderConfig()` returning the
global and leaves repeated construction non-destructive, while making it a real
class again. New: `RenderConfig.isolated()` and `cfg.copy()`.

`config=` now reaches every entry point that accepts it: `telegramify()` →
`process_markdown()` → `convert_with_segments()`, plus the Mermaid URL builders.
`pipeline.py` previously never mentioned `config` at all, so the parameter could
not do what its name promised. `richify()`/`telegramify_rich()` take no config
and say so in the contract — Rich HTML emits structural tags and reads no
symbols.

Documented in `docs/prd/render-config.md`.

## What review caught that the tests did not

Three of the defects above were regressions introduced by the first commit on
this branch. They were found by diffing every conversion output against the real
PyPI 1.2.0 and by two Codex review rounds, not by the suite.

The spoiler preprocessor's hand-rolled line scanner is gone as a result. It had
to reimplement CommonMark's container prefixes to decide what is code, and got
it wrong six ways: a single-line ` ```x``` ` span read as a fence opening, fences
nested in blockquotes and list items missed entirely, multi-line indented code
only half-marked, an invalid closing fence ending the state early, and a
paragraph line that looks like a list marker suppressing later indented code.
The blockquote and list cases were regressions against 1.2.0, which the old
regex happened to handle. pyromark now supplies the source byte ranges it treats
as code, so the parser that will read the text decides what counts as code in
it; documents without `||` skip the extra parse entirely.

Also fixed from review: a CRLF-wrapped spoiler was still dropped; the backward
blank-line scan counted only LF, losing CR-terminated sources that 1.2.0
handled; `utf16_len` raised on a lone surrogate where 1.2.0 counted it as one
code unit; the `<ol>` continuation budget ignored the extra digits a wider
`start` adds; a partially successful split bypassed the over-limit warning; and
`_extract_container` cut the open tag at a `>` inside a quoted attribute.

## Compatibility

Checked against the real 1.2.0 from PyPI, two ways.

**Public API surface** — only `config.singleton` and a re-exported
`typing.Awaitable` disappear. A GitHub-wide code search for imports from
`telegramify_markdown.config` returns `get_runtime_config` exclusively; zero hits
for `singleton`. `isinstance(cfg, RenderConfig)` goes from raising to working.

**Behaviour** — 31 cases including five real documents. 18 identical, 13 changed,
every change one of the fixes above. The one users will notice broadly is the
restored blank line after lists.

## Verification

- `pdm run test` — 294 pass
- `pdm run test-stream` — 23 pass
- `pdm run test-live-rich` and `pdm run test-live-stream` — pass against the real
  Bot API
- `make adr-lint`, `pdm build` (with `py.typed` in the wheel)

## Release

Version bumped to 1.3.0. `publish.yml` fires on a `pypi*` tag, so merging does
not publish — that needs `pypi_1.3.0` pushed separately.

## Known limits, unchanged by this PR

- A single atomic Rich block that cannot be split — one 40KB `<li>`, say — still
  goes out over the limit. The PRD sanctions this; it now warns per part.
- Splitting a table does not repeat the header row in later parts.
- `split_rich()` on caller-authored HTML relies on `_find_tag_end`, which can
  mis-pair on tag-like text inside an attribute value. `richify()` escapes every
  attribute, so its own output can never trigger it.

Closes #116.
